### PR TITLE
M2 and M30 do not pause workflow

### DIFF
--- a/src/app/controllers/Grbl/GrblController.js
+++ b/src/app/controllers/Grbl/GrblController.js
@@ -194,20 +194,14 @@ class GrblController {
                 const data = parser.parseLine(line, { flatten: true });
                 const words = ensureArray(data.words);
 
-                { // Program Mode: M0, M1, M2, M30
-                    const programMode = _.intersection(words, ['M0', 'M1', 'M2', 'M30'])[0];
+                { // Program Mode: M0, M1
+                    const programMode = _.intersection(words, ['M0', 'M1'])[0];
                     if (programMode === 'M0') {
                         log.debug('M0 Program Pause');
                         this.feeder.hold({ data: 'M0' }); // Hold reason
                     } else if (programMode === 'M1') {
                         log.debug('M1 Program Pause');
                         this.feeder.hold({ data: 'M1' }); // Hold reason
-                    } else if (programMode === 'M2') {
-                        log.debug('M2 Program End');
-                        this.feeder.hold({ data: 'M2' }); // Hold reason
-                    } else if (programMode === 'M30') {
-                        log.debug('M30 Program End');
-                        this.feeder.hold({ data: 'M30' }); // Hold reason
                     }
                 }
 
@@ -279,20 +273,14 @@ class GrblController {
                 const data = parser.parseLine(line, { flatten: true });
                 const words = ensureArray(data.words);
 
-                { // Program Mode: M0, M1, M2, M30
-                    const programMode = _.intersection(words, ['M0', 'M1', 'M2', 'M30'])[0];
+                { // Program Mode: M0, M1
+                    const programMode = _.intersection(words, ['M0', 'M1'])[0];
                     if (programMode === 'M0') {
                         log.debug(`M0 Program Pause: line=${sent + 1}, sent=${sent}, received=${received}`);
                         this.workflow.pause({ data: 'M0' });
                     } else if (programMode === 'M1') {
                         log.debug(`M1 Program Pause: line=${sent + 1}, sent=${sent}, received=${received}`);
                         this.workflow.pause({ data: 'M1' });
-                    } else if (programMode === 'M2') {
-                        log.debug(`M2 Program End: line=${sent + 1}, sent=${sent}, received=${received}`);
-                        this.workflow.pause({ data: 'M2' });
-                    } else if (programMode === 'M30') {
-                        log.debug(`M30 Program End: line=${sent + 1}, sent=${sent}, received=${received}`);
-                        this.workflow.pause({ data: 'M30' });
                     }
                 }
 

--- a/src/app/controllers/Marlin/MarlinController.js
+++ b/src/app/controllers/Marlin/MarlinController.js
@@ -368,20 +368,14 @@ class MarlinController {
                     this.feeder.hold({ data: 'M190' }); // Hold reason
                 }
 
-                { // Program Mode: M0, M1, M2, M30
-                    const programMode = _.intersection(words, ['M0', 'M1', 'M2', 'M30'])[0];
+                { // Program Mode: M0, M1
+                    const programMode = _.intersection(words, ['M0', 'M1'])[0];
                     if (programMode === 'M0') {
                         log.debug('M0 Program Pause');
                         this.feeder.hold({ data: 'M0' }); // Hold reason
                     } else if (programMode === 'M1') {
                         log.debug('M1 Program Pause');
                         this.feeder.hold({ data: 'M1' }); // Hold reason
-                    } else if (programMode === 'M2') {
-                        log.debug('M2 Program End');
-                        this.feeder.hold({ data: 'M2' }); // Hold reason
-                    } else if (programMode === 'M30') {
-                        log.debug('M30 Program End');
-                        this.feeder.hold({ data: 'M30' }); // Hold reason
                     }
                 }
 
@@ -467,20 +461,14 @@ class MarlinController {
                     this.sender.hold(reason); // Hold reason
                 }
 
-                { // Program Mode: M0, M1, M2, M30
-                    const programMode = _.intersection(words, ['M0', 'M1', 'M2', 'M30'])[0];
+                { // Program Mode: M0, M1
+                    const programMode = _.intersection(words, ['M0', 'M1'])[0];
                     if (programMode === 'M0') {
                         log.debug(`M0 Program Pause: line=${sent + 1}, sent=${sent}, received=${received}`);
                         this.workflow.pause({ data: 'M0' });
                     } else if (programMode === 'M1') {
                         log.debug(`M1 Program Pause: line=${sent + 1}, sent=${sent}, received=${received}`);
                         this.workflow.pause({ data: 'M1' });
-                    } else if (programMode === 'M2') {
-                        log.debug(`M2 Program End: line=${sent + 1}, sent=${sent}, received=${received}`);
-                        this.workflow.pause({ data: 'M2' });
-                    } else if (programMode === 'M30') {
-                        log.debug(`M30 Program End: line=${sent + 1}, sent=${sent}, received=${received}`);
-                        this.workflow.pause({ data: 'M30' });
                     }
                 }
 

--- a/src/app/controllers/Smoothie/SmoothieController.js
+++ b/src/app/controllers/Smoothie/SmoothieController.js
@@ -167,20 +167,14 @@ class SmoothieController {
                 const data = parser.parseLine(line, { flatten: true });
                 const words = ensureArray(data.words);
 
-                { // Program Mode: M0, M1, M2, M30
-                    const programMode = _.intersection(words, ['M0', 'M1', 'M2', 'M30'])[0];
+                { // Program Mode: M0, M1
+                    const programMode = _.intersection(words, ['M0', 'M1'])[0];
                     if (programMode === 'M0') {
                         log.debug('M0 Program Pause');
                         this.feeder.hold({ data: 'M0' }); // Hold reason
                     } else if (programMode === 'M1') {
                         log.debug('M1 Program Pause');
                         this.feeder.hold({ data: 'M1' }); // Hold reason
-                    } else if (programMode === 'M2') {
-                        log.debug('M2 Program End');
-                        this.feeder.hold({ data: 'M2' }); // Hold reason
-                    } else if (programMode === 'M30') {
-                        log.debug('M30 Program End');
-                        this.feeder.hold({ data: 'M30' }); // Hold reason
                     }
                 }
 
@@ -249,20 +243,14 @@ class SmoothieController {
                 const data = parser.parseLine(line, { flatten: true });
                 const words = ensureArray(data.words);
 
-                { // Program Mode: M0, M1, M2, M30
-                    const programMode = _.intersection(words, ['M0', 'M1', 'M2', 'M30'])[0];
+                { // Program Mode: M0, M1
+                    const programMode = _.intersection(words, ['M0', 'M1'])[0];
                     if (programMode === 'M0') {
                         log.debug(`M0 Program Pause: line=${sent + 1}, sent=${sent}, received=${received}`);
                         this.workflow.pause({ data: 'M0' });
                     } else if (programMode === 'M1') {
                         log.debug(`M1 Program Pause: line=${sent + 1}, sent=${sent}, received=${received}`);
                         this.workflow.pause({ data: 'M1' });
-                    } else if (programMode === 'M2') {
-                        log.debug(`M2 Program End: line=${sent + 1}, sent=${sent}, received=${received}`);
-                        this.workflow.pause({ data: 'M2' });
-                    } else if (programMode === 'M30') {
-                        log.debug(`M30 Program End: line=${sent + 1}, sent=${sent}, received=${received}`);
-                        this.workflow.pause({ data: 'M30' });
                     }
                 }
 

--- a/src/app/controllers/TinyG/TinyGController.js
+++ b/src/app/controllers/TinyG/TinyGController.js
@@ -166,20 +166,14 @@ class TinyGController {
                 const data = parser.parseLine(line, { flatten: true });
                 const words = ensureArray(data.words);
 
-                { // Program Mode: M0, M1, M2, M30
-                    const programMode = _.intersection(words, ['M0', 'M1', 'M2', 'M30'])[0];
+                { // Program Mode: M0, M1
+                    const programMode = _.intersection(words, ['M0', 'M1'])[0];
                     if (programMode === 'M0') {
                         log.debug('M0 Program Pause');
                         this.feeder.hold({ data: 'M0' }); // Hold reason
                     } else if (programMode === 'M1') {
                         log.debug('M1 Program Pause');
                         this.feeder.hold({ data: 'M1' }); // Hold reason
-                    } else if (programMode === 'M2') {
-                        log.debug('M2 Program End');
-                        this.feeder.hold({ data: 'M2' }); // Hold reason
-                    } else if (programMode === 'M30') {
-                        log.debug('M30 Program End');
-                        this.feeder.hold({ data: 'M30' }); // Hold reason
                     }
                 }
 
@@ -247,20 +241,14 @@ class TinyGController {
                 const data = parser.parseLine(line, { flatten: true });
                 const words = ensureArray(data.words);
 
-                { // Program Mode: M0, M1, M2, M30
-                    const programMode = _.intersection(words, ['M0', 'M1', 'M2', 'M30'])[0];
+                { // Program Mode: M0, M1
+                    const programMode = _.intersection(words, ['M0', 'M1'])[0];
                     if (programMode === 'M0') {
                         log.debug(`M0 Program Pause: line=${sent + 1}, sent=${sent}, received=${received}`);
                         this.workflow.pause({ data: 'M0' });
                     } else if (programMode === 'M1') {
                         log.debug(`M1 Program Pause: line=${sent + 1}, sent=${sent}, received=${received}`);
                         this.workflow.pause({ data: 'M1' });
-                    } else if (programMode === 'M2') {
-                        log.debug(`M2 Program End: line=${sent + 1}, sent=${sent}, received=${received}`);
-                        this.workflow.pause({ data: 'M2' });
-                    } else if (programMode === 'M30') {
-                        log.debug(`M30 Program End: line=${sent + 1}, sent=${sent}, received=${received}`);
-                        this.workflow.pause({ data: 'M30' });
                     }
                 }
 


### PR DESCRIPTION
Pausing the workflow on M2 and M30 is unnecessary and inappropriate.  Those commands are only used at the end of a GCode program, where there is no reason to require user action to return to the idle state.

Historically, back when CNC machines used punched paper tape, it was common to splice together multiple program tapes, either to set up a sequence of related programs, or to repeat one program by splicing the end of the tape to the beginning.  In that old use case, M30 and M2 were needed to mark the end of the tape or the boundary between programs, to prevent the tape reader from reading too far.  Now that GCode programs are stored in computer files, the tape model is no longer used, so M2 and M30 are essentially equivalent to "end of file".  Pausing with the possibility of resuming is no longer useful.

The disadvantage of pausing on M2 and M30 is that it requires the operator to perform an unnecessary and useless action - manually resuming only to have the program then return to the idle state.  That introduces a needless state - paused at the very end - that is confusing.

For interior pauses between sections of one program, there is M0 and M1.  It is appropriate for them to pause the workflow.