### PR TITLE
Fix for Marlin controller first-move bug (issue #312)

### DIFF
--- a/src/app/controllers/Marlin/MarlinController.js
+++ b/src/app/controllers/Marlin/MarlinController.js
@@ -561,6 +561,9 @@ class MarlinController {
         this.runner.on('start', (res) => {
             this.emit('serialport:read', res.raw);
 
+            // M115: Get Firmware Version and Capabilities
+            this.command('gcode', 'M115');
+
             // Set ready flag to true when receiving a start message
             // Note: It might have chance of receiving garbage characters on startup due to electronic noise.
             this.ready = true;
@@ -842,13 +845,6 @@ class MarlinController {
         }
     }
     async initController() {
-        // Wait for the bootloader to complete before sending commands
-        await delay(1000);
-
-        // M115: Get Firmware Version and Capabilities
-        this.command('gcode', 'M115');
-
-        this.ready = true;
     }
     get status() {
         return {


### PR DESCRIPTION
As described in #312, Marlin controllers can sometimes hang at startup until you manually send some Gcode (e.g. ` G0 X0`, at which point all queued commands run). This PR implements @cheton's recommended fix in [his comment](https://github.com/cncjs/cncjs/issues/312#issuecomment-401504386).