### PR TITLE
Fix an issue that dropdown menu gets clipped by container with overflow:hidden property (#445)

### DIFF
--- a/src/web/containers/Workspace/PrimaryWidgets.jsx
+++ b/src/web/containers/Workspace/PrimaryWidgets.jsx
@@ -214,9 +214,6 @@ class PrimaryWidgets extends Component {
         return (
             <Sortable
                 className={classNames(className, styles.widgets)}
-                style={{
-                    overflowX: 'hidden'
-                }}
                 options={{
                     animation: 150,
                     delay: 0, // Touch and hold delay

--- a/src/web/containers/Workspace/SecondaryWidgets.jsx
+++ b/src/web/containers/Workspace/SecondaryWidgets.jsx
@@ -213,9 +213,6 @@ class SecondaryWidgets extends Component {
         return (
             <Sortable
                 className={classNames(className, styles.widgets)}
-                style={{
-                    overflowX: 'hidden'
-                }}
                 options={{
                     animation: 150,
                     delay: 0, // Touch and hold delay

--- a/src/web/widgets/Axes/DisplayPanel.jsx
+++ b/src/web/widgets/Axes/DisplayPanel.jsx
@@ -1,5 +1,4 @@
 import chainedFunction from 'chained-function';
-import cx from 'classnames';
 import ensureArray from 'ensure-array';
 import includes from 'lodash/includes';
 import noop from 'lodash/noop';
@@ -1179,10 +1178,10 @@ class DisplayPanel extends PureComponent {
                 <table className="table-bordered">
                     <thead>
                         <tr>
-                            <th className="nowrap" title={i18n._('Axis')}>{i18n._('Axis')}</th>
-                            <th className="nowrap" title={i18n._('Machine Position')}>{i18n._('Machine Position')}</th>
-                            <th className="nowrap" title={i18n._('Work Position')}>{i18n._('Work Position')}</th>
-                            <th className={cx('nowrap', styles.action)}>
+                            <th title={i18n._('Axis')}>{i18n._('Axis')}</th>
+                            <th title={i18n._('Machine Position')}>{i18n._('Machine Position')}</th>
+                            <th title={i18n._('Work Position')}>{i18n._('Work Position')}</th>
+                            <th className={styles.action}>
                                 {this.renderActionDropdown({ wcs })}
                             </th>
                         </tr>


### PR DESCRIPTION
Closes #445 