### PR TITLE
Improve Marlin startup synchronization (#312)

### DIFF
--- a/src/server/controllers/Marlin/MarlinController.js
+++ b/src/server/controllers/Marlin/MarlinController.js
@@ -10,7 +10,6 @@ import Workflow, {
     WORKFLOW_STATE_PAUSED,
     WORKFLOW_STATE_RUNNING
 } from '../../lib/Workflow';
-import delay from '../../lib/delay';
 import ensurePositiveNumber from '../../lib/ensure-positive-number';
 import evaluateAssignmentExpression from '../../lib/evaluate-assignment-expression';
 import logger from '../../lib/logger';
@@ -82,7 +81,6 @@ class MarlinController {
     // Marlin
     controller = null;
     ready = false;
-    initialized = false;
     state = {};
     settings = {};
     feedOverride = 100;
@@ -561,17 +559,16 @@ class MarlinController {
 
         this.runner.on('start', (res) => {
             this.emit('serialport:read', res.raw);
-
-            // Set ready flag to true when a start message has arrived
-            // It might have chance of receiving garbage characters on startup due to electronic noise.
-            this.ready = true;
-
-            if (!this.initialized) {
-                this.initialized = true;
-
-                // Initialize controller
-                this.initController();
-            }
+            // Marlin sends 'start' as the first message after
+            // power-on, but not when the serial port is closed and
+            // then re-opened.  Marlin has no software-initiated
+            // restart, so 'start' is not dependable as a readiness
+            // indicator.  Instead, we send M115 on connection open
+            // to request a firmware report, whose response signals
+            // Marlin readiness.  On initial power-up, Marlin might
+            // miss that first M115 as it boots, so we send this
+            // possibly-redundant M115 when we see 'start'.
+            this.command('gcode', 'M115');
         });
 
         this.runner.on('echo', (res) => {
@@ -580,6 +577,11 @@ class MarlinController {
 
         this.runner.on('firmware', (res) => {
             this.emit('serialport:read', res.raw);
+            if (!this.ready) {
+                this.ready = true;
+                // Initialize controller
+                this.event.trigger('controller:ready');
+            }
         });
 
         this.runner.on('pos', (res) => {
@@ -761,13 +763,6 @@ class MarlinController {
             }
         }, 250);
     }
-    async initController() {
-        // M115: Get firmware version and capabilities
-        this.command('gcode', 'M115');
-
-        await delay(50);
-        this.event.trigger('controller:ready');
-    }
     populateContext(context) {
         // Work position
         const {
@@ -913,6 +908,10 @@ class MarlinController {
             callback(); // register controller
 
             log.debug(`Connected to serial port "${port}"`);
+
+            // M115: Get firmware version and capabilities
+            // The response to this will take us to the ready state
+            this.command('gcode', 'M115');
 
             this.workflow.stop();
 


### PR DESCRIPTION
Handle both initial Marlin power-on and connection close/re-open.

Marlin issues a 'start' line only on initial power-up.   If the serial connection to Marlin was closed and then re-opened, CNCjs would set it's ready variable to false and it would never go back to true because opening the connection would not result in a 'start' line.

The solution is use the 'firmware' response to indicate readiness, issuing an 'M115' firmware report request both on connection open and on receipt of 'start'.

This fix resulted in reliable position reports from Marlin in every scenario that I tested.