### PR TITLE
Fix Marlin startup regression from #464

### DIFF
--- a/src/server/controllers/Marlin/MarlinController.js
+++ b/src/server/controllers/Marlin/MarlinController.js
@@ -569,6 +569,7 @@ class MarlinController {
             // miss that first M115 as it boots, so we send this
             // possibly-redundant M115 when we see 'start'.
             this.command('gcode', 'M115');
+            this.feeder.next();
         });
 
         this.runner.on('echo', (res) => {

--- a/src/server/controllers/Marlin/MarlinController.js
+++ b/src/server/controllers/Marlin/MarlinController.js
@@ -568,8 +568,9 @@ class MarlinController {
             // Marlin readiness.  On initial power-up, Marlin might
             // miss that first M115 as it boots, so we send this
             // possibly-redundant M115 when we see 'start'.
-            this.command('gcode', 'M115');
-            this.feeder.next();
+            this.connection.write('M115\n', {
+                source: WRITE_SOURCE_SERVER
+            });
         });
 
         this.runner.on('echo', (res) => {
@@ -912,7 +913,9 @@ class MarlinController {
 
             // M115: Get firmware version and capabilities
             // The response to this will take us to the ready state
-            this.command('gcode', 'M115');
+            this.connection.write('M115\n', {
+                source: WRITE_SOURCE_SERVER
+            });
 
             this.workflow.stop();
 


### PR DESCRIPTION
PR #464 introduced a regression that caused a bug similar to #312, where Marlin would be unresponsive until a command was manually entered in the console (e.g. `G0 X0`). This PR includes the fix @MitchBradley suggested in [this comment](https://github.com/cncjs/cncjs/pull/464#issuecomment-489476430).

I've verified on my Marlin board that this fix solves the issue (UltiMachine Rambo running [github.comAllted/Marlin](https://github.com/Allted/Marlin/tree/MPCNC_Rambo_T8_16T_LCD_DualEndstop))