### PR TITLE
Fixed issue #318 - Marlin Inch Mode still shows MM in DRO

### DIFF
--- a/src/app/widgets/Axes/index.jsx
+++ b/src/app/widgets/Axes/index.jsx
@@ -506,20 +506,16 @@ class AxesWidget extends PureComponent {
                         type: type,
                         state: controllerState
                     },
-                    // Machine position are reported in current units
-                    machinePosition: mapValues({
+                    // Machine position is always reported in mm
+                    machinePosition: {
                         ...state.machinePosition,
                         ...pos
-                    }, (val) => {
-                        return (units === IMPERIAL_UNITS) ? in2mm(val) : val;
-                    }),
-                    // Work position are reported in current units
-                    workPosition: mapValues({
+                    },
+                    // Work position is always reported in mm
+                    workPosition:{
                         ...state.workPosition,
                         ...pos
-                    }, (val) => {
-                        return (units === IMPERIAL_UNITS) ? in2mm(val) : val;
-                    })
+                    }
                 }));
             }
 


### PR DESCRIPTION
Marlin always reports positions in mm, regardless of whether it is in inch (G20) or mm (G21) mode.