### PR TITLE
Fix missing space error

### DIFF
--- a/src/app/widgets/Axes/index.jsx
+++ b/src/app/widgets/Axes/index.jsx
@@ -512,7 +512,7 @@ class AxesWidget extends PureComponent {
                         ...pos
                     },
                     // Work position is always reported in mm
-                    workPosition:{
+                    workPosition: {
                         ...state.workPosition,
                         ...pos
                     }


### PR DESCRIPTION
Commit 86b9827 broke master as can be seen here https://travis-ci.org/cncjs/cncjs/builds/550912101 and the reason seems to be a missing space character. Which in turn causes a lint error.

Interestingly no such error can be seen in the logging output of the failed build, which is weird.