### PR TITLE
Add a Grbl jogCancel command

### DIFF
--- a/src/server/controllers/Grbl/GrblController.js
+++ b/src/server/controllers/Grbl/GrblController.js
@@ -35,7 +35,7 @@ import {
   GRBL_REALTIME_COMMANDS,
   GRBL_ALARMS,
   GRBL_ERRORS,
-  GRBL_SETTINGS
+  GRBL_SETTINGS,
 } from './constants';
 
 // % commands

--- a/src/server/lib/Feeder.js
+++ b/src/server/lib/Feeder.js
@@ -1,128 +1,133 @@
+import { ensureArray } from 'ensure-type';
 import events from 'events';
 
 class Feeder extends events.EventEmitter {
-    state = {
-      hold: false,
-      holdReason: null,
-      queue: [],
-      pending: false,
-      changed: false
+  state = {
+    hold: false,
+    holdReason: null,
+    queue: [],
+    pending: false,
+    changed: false,
+  };
+
+  dataFilter = null;
+
+  // @param {object} [options] The options object.
+  // @param {function} [options.dataFilter] A function to be used to handle the data. The function accepts two arguments: The data to be sent to the controller, and the context.
+  constructor(options) {
+    super();
+
+    if (typeof options.dataFilter === 'function') {
+      this.dataFilter = options.dataFilter;
+    }
+
+    this.on('change', () => {
+      this.state.changed = true;
+    });
+  }
+
+  toJSON() {
+    return {
+      hold: this.state.hold,
+      holdReason: this.state.holdReason,
+      queue: this.state.queue.length,
+      pending: this.state.pending,
+      changed: this.state.changed,
     };
+  }
 
-    dataFilter = null;
-
-    // @param {object} [options] The options object.
-    // @param {function} [options.dataFilter] A function to be used to handle the data. The function accepts two arguments: The data to be sent to the controller, and the context.
-    constructor(options) {
-      super();
-
-      if (typeof options.dataFilter === 'function') {
-        this.dataFilter = options.dataFilter;
-      }
-
-      this.on('change', () => {
-        this.state.changed = true;
-      });
-    }
-
-    toJSON() {
-      return {
-        hold: this.state.hold,
-        holdReason: this.state.holdReason,
-        queue: this.state.queue.length,
-        pending: this.state.pending,
-        changed: this.state.changed
-      };
-    }
-
-    feed(data = [], context = {}) {
-      // Clear pending state when the feeder queue is empty
-      if (this.state.queue.length === 0) {
-        this.state.pending = false;
-      }
-
-      data = [].concat(data);
-      if (data.length > 0) {
-        this.state.queue = this.state.queue.concat(data.map(command => {
-          return { command: command, context: context };
-        }));
-        this.emit('change');
-      }
-    }
-
-    hold(reason) {
-      if (this.state.hold) {
-        return;
-      }
-      this.state.hold = true;
-      this.state.holdReason = reason;
-      this.emit('hold');
-      this.emit('change');
-    }
-
-    unhold() {
-      if (!this.state.hold) {
-        return;
-      }
-      this.state.hold = false;
-      this.state.holdReason = null;
-      this.emit('unhold');
-      this.emit('change');
-    }
-
-    clear() {
-      this.state.queue = [];
+  // @param {string[]} data The data to be added to the queue.
+  // @param {object} [context] The context associated with the data.
+  feed(data, context = {}) {
+    // Clear pending state when the feeder queue is empty
+    if (this.state.queue.length === 0) {
       this.state.pending = false;
+    }
+
+    data = ensureArray(data);
+    if (data.length > 0) {
+      const queueItems = data.map(command => ({
+        command,
+        context,
+      }));
+      this.state.queue = this.state.queue.concat(queueItems);
       this.emit('change');
     }
+  }
 
-    reset() {
-      this.state.hold = false;
-      this.state.holdReason = null;
-      this.state.queue = [];
-      this.state.pending = false;
-      this.emit('change');
+  hold(reason) {
+    if (this.state.hold) {
+      return;
     }
+    this.state.hold = true;
+    this.state.holdReason = reason;
+    this.emit('hold');
+    this.emit('change');
+  }
 
-    size() {
-      return this.state.queue.length;
+  unhold() {
+    if (!this.state.hold) {
+      return;
     }
+    this.state.hold = false;
+    this.state.holdReason = null;
+    this.emit('unhold');
+    this.emit('change');
+  }
 
-    next() {
-      while (!this.state.hold && this.state.queue.length > 0) {
-        let { command, context } = this.state.queue.shift();
+  clear() {
+    this.state.queue = [];
+    this.state.pending = false;
+    this.emit('change');
+  }
 
-        if (this.dataFilter) {
-          command = this.dataFilter(command, context) || '';
-          if (!command) { // Ignore blank lines
-            continue;
-          }
+  reset() {
+    this.state.hold = false;
+    this.state.holdReason = null;
+    this.state.queue = [];
+    this.state.pending = false;
+    this.emit('change');
+  }
+
+  size() {
+    return this.state.queue.length;
+  }
+
+  next() {
+    while (!this.state.hold && this.state.queue.length > 0) {
+      let { command, context } = this.state.queue.shift();
+
+      if (this.dataFilter) {
+        command = this.dataFilter(command, context) || '';
+        if (!command) { // Ignore blank lines
+          continue;
         }
-
-        this.state.pending = true;
-        this.emit('data', command, context);
-        this.emit('change');
-        break;
       }
 
-      // Clear pending state when the feeder queue is empty
-      if (this.state.queue.length === 0) {
-        this.state.pending = false;
-      }
-
-      return this.state.pending;
+      this.state.pending = true;
+      this.emit('data', command, context);
+      this.emit('change');
+      break;
     }
 
-    isPending() {
-      return this.state.pending;
+    // Clear pending state when the feeder queue is empty
+    if (this.state.queue.length === 0) {
+      this.state.pending = false;
     }
 
-    // Returns true if any state have changes
-    peek() {
-      const changed = this.state.changed;
-      this.state.changed = false;
-      return changed;
-    }
+    return this.state.pending;
+  }
+
+  isPending() {
+    return this.state.pending;
+  }
+
+  // Returns true if any state have changes
+  peek() {
+    const changed = this.state.changed;
+    this.state.changed = false;
+    return changed;
+  }
 }
 
 export default Feeder;


### PR DESCRIPTION
Grbl v1.1 controllers support additional Extended Ascii Realtime
Comands:
https://github.com/gnea/grbl/wiki/Grbl-v1.1-Commands#extended-ascii-realtime-command-descriptions

The jogCancel command is sent as the character 0x85, and is useful
for implementing Grbl v1.1 jogging:
https://github.com/gnea/grbl/wiki/Grbl-v1.1-Jogging

The 0x85 character cannot be sent over socket.io as an argument to
the gcode command because it does not form a valid UTF8 byte
sequence.  Add a jogCancel command that causes CNCjs to send
the 0x85 character to the Grbl controller.