### PR TITLE
Add support for host commands (e.g. action:pause) and use suspend/resume instead of !/~ 

### DIFF
--- a/src/server/controllers/Smoothie/SmoothieController.js
+++ b/src/server/controllers/Smoothie/SmoothieController.js
@@ -1004,7 +1004,7 @@ class SmoothieController {
 
                 const activeState = _.get(this.state, 'status.activeState', '');
                 if (activeState === SMOOTHIE_ACTIVE_STATE_HOLD) {
-                    this.write('~'); // resume
+                    this.writeln('resume'); // resume
                 }
             },
             'pause': () => {
@@ -1016,7 +1016,7 @@ class SmoothieController {
 
                 this.workflow.pause();
 
-                this.write('!');
+                this.writeln('suspend');
             },
             'resume': () => {
                 log.warn(`Warning: The "${cmd}" command is deprecated and will be removed in a future release.`);
@@ -1025,7 +1025,7 @@ class SmoothieController {
             'gcode:resume': () => {
                 this.event.trigger('gcode:resume');
 
-                this.write('~');
+                this.writeln('resume');
 
                 this.workflow.resume();
             },
@@ -1037,7 +1037,7 @@ class SmoothieController {
                 if (this.workflow.state === WORKFLOW_STATE_RUNNING) {
                     return;
                 }
-                this.write('~');
+                this.writeln('resume');
                 this.feeder.unhold();
                 this.feeder.next();
             },
@@ -1047,12 +1047,12 @@ class SmoothieController {
             'feedhold': () => {
                 this.event.trigger('feedhold');
 
-                this.write('!');
+                this.writeln('suspend');
             },
             'cyclestart': () => {
                 this.event.trigger('cyclestart');
 
-                this.write('~');
+                this.writeln('resume');
             },
             'statusreport': () => {
                 this.write('?');

--- a/src/server/controllers/Smoothie/SmoothieController.js
+++ b/src/server/controllers/Smoothie/SmoothieController.js
@@ -455,6 +455,20 @@ class SmoothieController {
             this.emit('serialport:read', res.raw);
         });
 
+        // handle action:xxx host commands
+        this.runner.on('action', (res) => {
+            log.error(`incoming action: action:${res.message} !`);
+            if (res.message === 'pause') {
+                this.workflow.pause({ data: 'action:pause' });
+            } else if (res.message === 'resume') {
+                this.workflow.resume({ data: 'action:resume' });
+            } else if (res.message === 'cancel') {
+                this.workflow.stop();
+            } else {
+                log.error(`Unknown action command: action:${res.message} ignored`);
+            }
+        });
+
         this.runner.on('parserstate', (res) => {
             this.actionMask.queryParserState.state = false;
             this.actionMask.queryParserState.reply = true;

--- a/src/server/controllers/Smoothie/SmoothieLineParser.js
+++ b/src/server/controllers/Smoothie/SmoothieLineParser.js
@@ -3,6 +3,7 @@ import SmoothieLineParserResultStatus from './SmoothieLineParserResultStatus';
 import SmoothieLineParserResultOk from './SmoothieLineParserResultOk';
 import SmoothieLineParserResultError from './SmoothieLineParserResultError';
 import SmoothieLineParserResultAlarm from './SmoothieLineParserResultAlarm';
+import SmoothieLineParserResultAction from './SmoothieLineParserResultAction';
 import SmoothieLineParserResultParserState from './SmoothieLineParserResultParserState';
 import SmoothieLineParserResultParameters from './SmoothieLineParserResultParameters';
 import SmoothieLineParserResultVersion from './SmoothieLineParserResultVersion';
@@ -21,6 +22,9 @@ class SmoothieLineParser {
 
             // ALARM:
             SmoothieLineParserResultAlarm,
+
+            // action:x
+            SmoothieLineParserResultAction,
 
             // [G38.2 G54 G17 G21 G91 G94 M0 M5 M9 T0 F20. S0.]
             SmoothieLineParserResultParserState,

--- a/src/server/controllers/Smoothie/SmoothieLineParserResultAction.js
+++ b/src/server/controllers/Smoothie/SmoothieLineParserResultAction.js
@@ -1,0 +1,22 @@
+class SmoothieLineParserResultAction {
+    static parse(line) {
+        // handle action commands from the host
+        // see https://reprap.org/wiki/G-code#Replies_from_the_RepRap_machine_to_the_host_computer
+        // '// action:{pause,resume,cancel}\r\n'
+        const r = line.match(/^\/\/ action:(.+)$/);
+        if (!r) {
+            return null;
+        }
+
+        const payload = {
+            message: r[1]
+        };
+
+        return {
+            type: SmoothieLineParserResultAction,
+            payload: payload
+        };
+    }
+}
+
+export default SmoothieLineParserResultAction;

--- a/src/server/controllers/Smoothie/SmoothieRunner.js
+++ b/src/server/controllers/Smoothie/SmoothieRunner.js
@@ -5,6 +5,7 @@ import SmoothieLineParserResultStatus from './SmoothieLineParserResultStatus';
 import SmoothieLineParserResultOk from './SmoothieLineParserResultOk';
 import SmoothieLineParserResultError from './SmoothieLineParserResultError';
 import SmoothieLineParserResultAlarm from './SmoothieLineParserResultAlarm';
+import SmoothieLineParserResultAction from './SmoothieLineParserResultAction';
 import SmoothieLineParserResultParserState from './SmoothieLineParserResultParserState';
 import SmoothieLineParserResultParameters from './SmoothieLineParserResultParameters';
 import SmoothieLineParserResultVersion from './SmoothieLineParserResultVersion';
@@ -101,6 +102,10 @@ class SmoothieRunner extends events.EventEmitter {
         }
         if (type === SmoothieLineParserResultAlarm) {
             this.emit('alarm', payload);
+            return;
+        }
+        if (type === SmoothieLineParserResultAction) {
+            this.emit('action', payload);
             return;
         }
         if (type === SmoothieLineParserResultParserState) {


### PR DESCRIPTION
This pull requests adds support for the smoothieboard host commands.

If you suspend the Smoothieboard via a button it sends action:pause to the host.
This patch takes care of stopping and resuming cncjs properly.

While testing the code I stumbled upon the following issue:
When the board is halted by the push button my fork stops cncjs.
Clicking on resume in cncjs sends a ~ which will start sending data but does not clear the halted state in the Smoothieboard firmware.
The devs at Smoothieware told me that !/~ is not supported and should not be used:
https://github.com/Smoothieware/Smoothieware/issues/1427

This is why this patch includes the change from !/~ to suspend and resume as well.