### PR TITLE
Patch 1  - run Macro Now update

### DIFF
--- a/src/app/widgets/Macro/Macro.jsx
+++ b/src/app/widgets/Macro/Macro.jsx
@@ -22,8 +22,14 @@ class Macro extends PureComponent {
     };
 
     handleRunMacro = (macro) => (event) => {
-        const { actions } = this.props;
-        actions.openRunMacroModal(macro.id);
+        global.runMacroNow = true; //FIX with global setting in Macro or other
+        if (typeof global.runMacroNow !== 'undefined' && global.runMacroNow === true) {
+            const { actions } = this.props;
+            actions.openRunMacroNow(macro.id, macro.name);
+        } else {
+            const { actions } = this.props;
+            actions.openRunMacroModal(macro.id);
+        }
     };
 
     handleLoadMacro = (macro) => (event) => {

--- a/src/app/widgets/Macro/index.jsx
+++ b/src/app/widgets/Macro/index.jsx
@@ -170,6 +170,9 @@ class MacroWidget extends PureComponent {
                     this.actions.openModal(MODAL_RUN_MACRO, { id, name, content });
                 });
         },
+        openRunMacroNow: (id, name) => {
+            this.actions.runMacro(id, { name });
+        },        
         openEditMacroModal: (id) => {
             api.macros.read(id)
                 .then((res) => {


### PR DESCRIPTION
This patch allows running the Macro directly from the Macro list items "Run Macro" buttons.
It is hoped that the global.runMacroNow variable can be set true or false within a Macro to enable this feature and disable it at any time by the user.  Currently global.runMacroNow is hard coded to true in Macro.jsx