### PR TITLE
Added 76800 baud

### DIFF
--- a/src/app/widgets/Connection/index.jsx
+++ b/src/app/widgets/Connection/index.jsx
@@ -243,6 +243,7 @@ class ConnectionWidget extends PureComponent {
         const defaultBaudrates = [
             250000,
             115200,
+            76800,
             57600,
             38400,
             19200,


### PR DESCRIPTION
Some printers/cncs are using 76800baud

Why?

Running a 16Mhz ATmega2560 at the more common 115200 baud is not recommended as the error rate of 3% would be above what the spec tolerates, because of the clock mismatch 16Mhz is not divisible by 300.
So the next more appropriate rate is 76800 baud with a much cleaner transmission with an error rate of about 0.2%.

76800 is also referred as 38400 double rate, and some ESP-12 also use 76.8K baud.

Sources:
https://www.robotroom.com/Asynchronous-Serial-Communication-2.html
https://trolsoft.ru/en/uart-calc