### PR TITLE
Improve Docker builds (introduces: armhf support)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,10 @@ RUN [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && \
 
 ADD bin/docker-entrypoint /bin/docker-entrypoint
 
+RUN groupadd --gid 1000 cncjs \
+    && useradd --uid 1000 --gid cncjs --shell /bin/bash --create-home cncjs
+USER cncjs
+WORKDIR /home/cncjs
+
 EXPOSE 8000
 CMD ["/bin/docker-entrypoint"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,27 @@
-FROM node:10
-MAINTAINER Cheton Wu <cheton@gmail.com>
+FROM debian:stretch
+MAINTAINER Zane Claes <zane@technicallywizardry.com>
 
-ADD package.json package.json
-RUN npm i npm@latest -g
-RUN npm install --production
+# Install global dependencies
+RUN apt-get update -y && \
+  apt-get install --no-install-recommends -y \
+    python-pip git curl make g++ udev
 
-ADD . .
+# Install NVM & Node 10
+RUN git clone https://github.com/creationix/nvm.git /nvm && \
+  cd /nvm && \
+  git checkout `git describe --abbrev=0 --tags` && \
+  chmod +x /nvm/nvm.sh && /nvm/nvm.sh
+
+ENV NVM_DIR="/nvm"
+RUN [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && \
+  nvm install 10 && nvm use 10 && \
+  npm i npm@latest -g
+
+# Install CNCjs
+RUN [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && \
+  npm install --unsafe-perm -g cncjs
+
+ADD bin/docker-entrypoint /bin/docker-entrypoint
+
 EXPOSE 8000
-CMD ["bin/cncjs"]
+CMD ["/bin/docker-entrypoint"]

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,0 +1,2 @@
+#!/bin/bash
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && cncjs "$@"


### PR DESCRIPTION
This PR improves the Dockerfile behavior:

- Supports `armhf` (Raspberry Pi).
- Uses a lighter weight base image (smaller size).
- Supports command line arguments.
- Installs from the public, stable release.

The RPi image is pushed to `inzania/cnc-js:armhf`.

Is there a CI already in place for Docker builds? Looks like Travis is running on the branch...