### PR TITLE
Return as-loaded gcode in gcode:load event

### DIFF
--- a/src/server/controllers/Grbl/GrblController.js
+++ b/src/server/controllers/Grbl/GrblController.js
@@ -1068,13 +1068,14 @@ class GrblController {
                 // be no queued motions, as long as no more commands were sent after the G4.
                 // This is the fastest way to do it without having to check the status reports.
                 const dwell = '%wait ; Wait for the planner to empty';
-                const ok = this.sender.load(name, gcode + '\n' + dwell, context);
+                const gcodeWithDwell = gcode + '\n' + dwell;
+                const ok = this.sender.load(name, gcodeWithDwell, context);
                 if (!ok) {
                     callback(new Error(`Invalid G-code: name=${name}`));
                     return;
                 }
 
-                this.emit('gcode:load', name, gcode, context);
+                this.emit('gcode:load', name, gcodeWithDwell, context);
                 this.event.trigger('gcode:load');
 
                 log.debug(`Load G-code: name="${this.sender.state.name}", size=${this.sender.state.gcode.length}, total=${this.sender.state.total}`);

--- a/src/server/controllers/Grbl/GrblController.js
+++ b/src/server/controllers/Grbl/GrblController.js
@@ -1068,14 +1068,13 @@ class GrblController {
                 // be no queued motions, as long as no more commands were sent after the G4.
                 // This is the fastest way to do it without having to check the status reports.
                 const dwell = '%wait ; Wait for the planner to empty';
-                const gcodeWithDwell = gcode + '\n' + dwell;
-                const ok = this.sender.load(name, gcodeWithDwell, context);
+                const ok = this.sender.load(name, gcode + '\n' + dwell, context);
                 if (!ok) {
                     callback(new Error(`Invalid G-code: name=${name}`));
                     return;
                 }
 
-                this.emit('gcode:load', name, gcodeWithDwell, context);
+                this.emit('gcode:load', name, this.sender.state.gcode, context);
                 this.event.trigger('gcode:load');
 
                 log.debug(`Load G-code: name="${this.sender.state.name}", size=${this.sender.state.gcode.length}, total=${this.sender.state.total}`);

--- a/src/server/controllers/Marlin/MarlinController.js
+++ b/src/server/controllers/Marlin/MarlinController.js
@@ -1082,13 +1082,14 @@ class MarlinController {
                 // be no queued motions, as long as no more commands were sent after the G4.
                 // This is the fastest way to do it without having to check the status reports.
                 const dwell = '%wait ; Wait for the planner to empty';
-                const ok = this.sender.load(name, gcode + '\n' + dwell, context);
+                const gcodeWithDwell = gcode + '\n' + dwell;
+                const ok = this.sender.load(name, gcodeWithDwell, context);
                 if (!ok) {
                     callback(new Error(`Invalid G-code: name=${name}`));
                     return;
                 }
 
-                this.emit('gcode:load', name, gcode, context);
+                this.emit('gcode:load', name, gcodeWithDwell, context);
                 this.event.trigger('gcode:load');
 
                 log.debug(`Load G-code: name="${this.sender.state.name}", size=${this.sender.state.gcode.length}, total=${this.sender.state.total}`);

--- a/src/server/controllers/Marlin/MarlinController.js
+++ b/src/server/controllers/Marlin/MarlinController.js
@@ -1082,14 +1082,13 @@ class MarlinController {
                 // be no queued motions, as long as no more commands were sent after the G4.
                 // This is the fastest way to do it without having to check the status reports.
                 const dwell = '%wait ; Wait for the planner to empty';
-                const gcodeWithDwell = gcode + '\n' + dwell;
-                const ok = this.sender.load(name, gcodeWithDwell, context);
+                const ok = this.sender.load(name, gcode + '\n' + dwell, context);
                 if (!ok) {
                     callback(new Error(`Invalid G-code: name=${name}`));
                     return;
                 }
 
-                this.emit('gcode:load', name, gcodeWithDwell, context);
+                this.emit('gcode:load', name, this.sender.state.gcode, context);
                 this.event.trigger('gcode:load');
 
                 log.debug(`Load G-code: name="${this.sender.state.name}", size=${this.sender.state.gcode.length}, total=${this.sender.state.total}`);

--- a/src/server/controllers/Smoothie/SmoothieController.js
+++ b/src/server/controllers/Smoothie/SmoothieController.js
@@ -1000,14 +1000,13 @@ class SmoothieController {
                 // be no queued motions, as long as no more commands were sent after the G4.
                 // This is the fastest way to do it without having to check the status reports.
                 const dwell = '%wait ; Wait for the planner to empty';
-                const gcodeWithDwell = gcode + '\n' + dwell;
-                const ok = this.sender.load(name, gcodeWithDwell, context);
+                const ok = this.sender.load(name, gcode + '\n' + dwell, context);
                 if (!ok) {
                     callback(new Error(`Invalid G-code: name=${name}`));
                     return;
                 }
 
-                this.emit('gcode:load', name, gcodeWithDwell, context);
+                this.emit('gcode:load', name, this.sender.state.gcode, context);
                 this.event.trigger('gcode:load');
 
                 log.debug(`Load G-code: name="${this.sender.state.name}", size=${this.sender.state.gcode.length}, total=${this.sender.state.total}`);

--- a/src/server/controllers/Smoothie/SmoothieController.js
+++ b/src/server/controllers/Smoothie/SmoothieController.js
@@ -1000,13 +1000,14 @@ class SmoothieController {
                 // be no queued motions, as long as no more commands were sent after the G4.
                 // This is the fastest way to do it without having to check the status reports.
                 const dwell = '%wait ; Wait for the planner to empty';
-                const ok = this.sender.load(name, gcode + '\n' + dwell, context);
+                const gcodeWithDwell = gcode + '\n' + dwell;
+                const ok = this.sender.load(name, gcodeWithDwell, context);
                 if (!ok) {
                     callback(new Error(`Invalid G-code: name=${name}`));
                     return;
                 }
 
-                this.emit('gcode:load', name, gcode, context);
+                this.emit('gcode:load', name, gcodeWithDwell, context);
                 this.event.trigger('gcode:load');
 
                 log.debug(`Load G-code: name="${this.sender.state.name}", size=${this.sender.state.gcode.length}, total=${this.sender.state.total}`);

--- a/src/server/controllers/TinyG/TinyGController.js
+++ b/src/server/controllers/TinyG/TinyGController.js
@@ -1100,13 +1100,14 @@ class TinyGController {
                 // be no queued motions, as long as no more commands were sent after the G4.
                 // This is the fastest way to do it without having to check the status reports.
                 const dwell = '%wait ; Wait for the planner to empty';
-                const ok = this.sender.load(name, gcode + '\n' + dwell, context);
+                const gcodeWithDwell = gcode + '\n' + dwell;
+                const ok = this.sender.load(name, gcodeWithDwell, context);
                 if (!ok) {
                     callback(new Error(`Invalid G-code: name=${name}`));
                     return;
                 }
 
-                this.emit('gcode:load', name, gcode, context);
+                this.emit('gcode:load', name, gcodeWithDwell, context);
                 this.event.trigger('gcode:load');
 
                 log.debug(`Load G-code: name="${this.sender.state.name}", size=${this.sender.state.gcode.length}, total=${this.sender.state.total}`);

--- a/src/server/controllers/TinyG/TinyGController.js
+++ b/src/server/controllers/TinyG/TinyGController.js
@@ -1100,14 +1100,13 @@ class TinyGController {
                 // be no queued motions, as long as no more commands were sent after the G4.
                 // This is the fastest way to do it without having to check the status reports.
                 const dwell = '%wait ; Wait for the planner to empty';
-                const gcodeWithDwell = gcode + '\n' + dwell;
-                const ok = this.sender.load(name, gcodeWithDwell, context);
+                const ok = this.sender.load(name, gcode + '\n' + dwell, context);
                 if (!ok) {
                     callback(new Error(`Invalid G-code: name=${name}`));
                     return;
                 }
 
-                this.emit('gcode:load', name, gcodeWithDwell, context);
+                this.emit('gcode:load', name, this.sender.state.gcode, context);
                 this.event.trigger('gcode:load');
 
                 log.debug(`Load G-code: name="${this.sender.state.name}", size=${this.sender.state.gcode.length}, total=${this.sender.state.total}`);


### PR DESCRIPTION
While debugging programs, it's confusing for the g-code list view to show a different number of lines than the g-code widget.  This comes from the fact that the load routines remove blank lines and add a dwell at the end of the program.
This PR syncs those up by returning the as-loaded gcode in the gcode:load event.