### PR TITLE
Also show toast notifications on g-code listing view of Visualizer (fixes #614)

### DIFF
--- a/src/app/widgets/Visualizer/index.jsx
+++ b/src/app/widgets/Visualizer/index.jsx
@@ -1017,7 +1017,7 @@ class VisualizerWidget extends PureComponent {
         };
         const showDashboard = !capable.view3D && !showLoader;
         const showVisualizer = capable.view3D && !showLoader;
-        const showNotifications = showVisualizer && !!state.notification.type;
+        const showNotifications = !!state.notification.type;
 
         return (
             <Widget borderless>

--- a/src/app/widgets/Visualizer/index.jsx
+++ b/src/app/widgets/Visualizer/index.jsx
@@ -1080,14 +1080,16 @@ class VisualizerWidget extends PureComponent {
                         />
                     )}
                 </Widget.Content>
-                <Widget.Footer className={styles.widgetFooter}>
-                    <SecondaryToolbar
-                        is3DView={capable.view3D}
-                        cameraMode={state.cameraMode}
-                        cameraPosition={state.cameraPosition}
-                        camera={actions.camera}
-                    />
-                </Widget.Footer>
+                {showVisualizer && (
+                    <Widget.Footer className={styles.widgetFooter}>
+                        <SecondaryToolbar
+                            is3DView={capable.view3D}
+                            cameraMode={state.cameraMode}
+                            cameraPosition={state.cameraPosition}
+                            camera={actions.camera}
+                        />
+                    </Widget.Footer>
+                )}
             </Widget>
         );
     }


### PR DESCRIPTION
Fixes #614 by showing notifications on both views.  Also removes footer/toolbar from the listing view where it is not used and also obscures the bottom part of the listing.