### PR TITLE
Allow for optional State prefix of GC

### DIFF
--- a/src/server/controllers/Smoothie/SmoothieLineParserResultParserState.js
+++ b/src/server/controllers/Smoothie/SmoothieLineParserResultParserState.js
@@ -11,14 +11,18 @@ import {
 
 class SmoothieLineParserResultParserState {
     // [G38.2 G54 G17 G21 G91 G94 M0 M5 M9 T0 F20. S0.]
+
+    // Smoothieware edge as of 11/2020 has a hardcoded GC: prefixing the state
+    // [GC:G0 G54 G17 G21 G90 G94 M0 M5 M9 T0 F2000.0 S2000.0]
+
     static parse(line) {
-        const r = line.match(/^\[((?:[a-zA-Z][0-9]+(?:\.[0-9]*)?\s*)+)\]$/);
+        const r = line.match(/^\[(GC:)?((?:[a-zA-Z][0-9]+(?:\.[0-9]*)?\s*)+)\]$/);
         if (!r) {
             return null;
         }
 
         const payload = {};
-        const words = _compact(r[1].split(' '))
+        const words = _compact(r[2].split(' '))
             .map((word) => {
                 return _trim(word);
             });


### PR DESCRIPTION
Smoothieware edge returns a State string prefixed with hardcoded `GC:`