### PR TITLE
Updated Marlin start message parsing

### DIFF
--- a/src/server/controllers/Marlin/MarlinLineParserResultStart.js
+++ b/src/server/controllers/Marlin/MarlinLineParserResultStart.js
@@ -1,7 +1,7 @@
 class MarlinLineParserResultStart {
     // start
     static parse(line) {
-        const r = line.match(/^start$/);
+        const r = line.match(/^(?:echo:)start$/);
         if (!r) {
             return null;
         }


### PR DESCRIPTION
Some flavors of Marlin print 'echo:start' on serial connect instead of plain 'start'.
The controller will not finish its connection sequence and will seem unresponsive.