### PR TITLE
install udev system dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:10
 MAINTAINER Cheton Wu <cheton@gmail.com>
 
+RUN apt-get update
+RUN apt-get install -y udev
+
 ADD package.json package.json
 RUN npm i npm@latest -g
 RUN npm install --production


### PR DESCRIPTION
This solves this error:
```
error service:cncengine { Error: spawn udevadm ENOENT
  at Process.ChildProcess._handle.onexit (internal/child_process.js:240:19)
  at onErrorNT (internal/child_process.js:415:16)
  at process._tickCallback (internal/process/next_tick.js:63:19)
errno: 'ENOENT',
code: 'ENOENT',
syscall: 'spawn udevadm',
path: 'udevadm',
spawnargs: [ 'info', '-e' ] }
```