### PR TITLE
Propagate line comments in GRBL M0/M1/M6 commands to UI dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,6 +180,7 @@
     "detect-browser": "~4.4.0",
     "electron-store": "~3.2.0",
     "ensure-array": "~1.0.0",
+    "ensure-type": "~1.5.1",
     "errorhandler": "~1.5.0",
     "es5-shim": "~4.5.13",
     "escodegen": "~1.11.1",

--- a/src/app/containers/Workspace/Workspace.jsx
+++ b/src/app/containers/Workspace/Workspace.jsx
@@ -151,18 +151,20 @@ class Workspace extends PureComponent {
                 return;
             }
 
-            const { err, data } = { ...holdReason };
+            const { err, data, msg } = { ...holdReason };
 
             if (err) {
                 this.action.openModal(MODAL_FEEDER_PAUSED, {
-                    title: i18n._('Error')
+                    title: i18n._('Error'),
+                    message: msg,
                 });
                 return;
             }
 
             if (data === WAIT) {
                 this.action.openModal(MODAL_FEEDER_WAIT, {
-                    title: '%wait'
+                    title: '%wait',
+                    message: msg,
                 });
                 return;
             }
@@ -178,7 +180,8 @@ class Workspace extends PureComponent {
             }[data] || data;
 
             this.action.openModal(MODAL_FEEDER_PAUSED, {
-                title: title
+                title: title,
+                message: msg,
             });
         }
     };
@@ -433,12 +436,14 @@ class Workspace extends PureComponent {
                 {modal.name === MODAL_FEEDER_PAUSED && (
                     <FeederPaused
                         title={modal.params.title}
+                        message={modal.params.message}
                         onClose={this.action.closeModal}
                     />
                 )}
                 {modal.name === MODAL_FEEDER_WAIT && (
                     <FeederWait
                         title={modal.params.title}
+                        message={modal.params.message}
                         onClose={this.action.closeModal}
                     />
                 )}

--- a/src/app/containers/Workspace/modals/FeederPaused.jsx
+++ b/src/app/containers/Workspace/modals/FeederPaused.jsx
@@ -7,7 +7,11 @@ import Modal from 'app/components/Modal';
 import controller from 'app/lib/controller';
 import i18n from 'app/lib/i18n';
 
-const FeederPaused = (props) => (
+const FeederPaused = ({
+    title,
+    message,
+    onClose,
+}) => (
     <Modal
         size="xs"
         disableOverlay={true}
@@ -15,7 +19,10 @@ const FeederPaused = (props) => (
     >
         <Modal.Body>
             <ModalTemplate type="warning">
-                <h5>{props.title}</h5>
+                <h5>{title}</h5>
+                {message &&
+                    <p>{message}</p>
+                }
                 <p>{i18n._('Click the Continue button to resume execution.')}</p>
             </ModalTemplate>
         </Modal.Body>
@@ -27,7 +34,7 @@ const FeederPaused = (props) => (
                     () => {
                         controller.command('feeder:stop');
                     },
-                    props.onClose
+                    onClose
                 )}
             >
                 {i18n._('Stop')}
@@ -37,7 +44,7 @@ const FeederPaused = (props) => (
                     () => {
                         controller.command('feeder:start');
                     },
-                    props.onClose
+                    onClose
                 )}
             >
                 {i18n._('Continue')}
@@ -48,6 +55,7 @@ const FeederPaused = (props) => (
 
 FeederPaused.propTypes = {
     title: PropTypes.string,
+    message: PropTypes.string,
     onClose: PropTypes.func
 };
 

--- a/src/app/containers/Workspace/modals/FeederWait.jsx
+++ b/src/app/containers/Workspace/modals/FeederWait.jsx
@@ -7,7 +7,11 @@ import Modal from 'app/components/Modal';
 import controller from 'app/lib/controller';
 import i18n from 'app/lib/i18n';
 
-const FeederWait = (props) => (
+const FeederWait = ({
+    title,
+    message,
+    onClose,
+}) => (
     <Modal
         size="xs"
         disableOverlay={true}
@@ -15,7 +19,10 @@ const FeederWait = (props) => (
     >
         <Modal.Body>
             <ModalTemplate type="warning">
-                <h5>{props.title}</h5>
+                <h5>{title}</h5>
+                {message &&
+                    <p>{message}</p>
+                }
                 <p>{i18n._('Waiting for the planner to empty...')}</p>
             </ModalTemplate>
         </Modal.Body>
@@ -26,7 +33,7 @@ const FeederWait = (props) => (
                     () => {
                         controller.command('feeder:stop');
                     },
-                    props.onClose
+                    onClose
                 )}
             >
                 {i18n._('Stop')}
@@ -37,6 +44,7 @@ const FeederWait = (props) => (
 
 FeederWait.propTypes = {
     title: PropTypes.string,
+    message: PropTypes.string,
     onClose: PropTypes.func
 };
 

--- a/src/package.json
+++ b/src/package.json
@@ -27,6 +27,7 @@
     "deep-keys": "~0.5.0",
     "electron-store": "~3.2.0",
     "ensure-array": "~1.0.0",
+    "ensure-type": "~1.5.1",
     "errorhandler": "~1.5.0",
     "escodegen": "~1.11.1",
     "esprima": "~4.0.1",

--- a/src/server/controllers/Marlin/MarlinController.js
+++ b/src/server/controllers/Marlin/MarlinController.js
@@ -1,4 +1,7 @@
-import ensureArray from 'ensure-array';
+import {
+    ensureArray,
+    ensureString,
+} from 'ensure-type';
 import * as parser from 'gcode-parser';
 import _ from 'lodash';
 import SerialConnection from '../../lib/SerialConnection';
@@ -345,8 +348,13 @@ class MarlinController {
         // Feeder
         this.feeder = new Feeder({
             dataFilter: (line, context) => {
-                // Remove comments that start with a semicolon `;`
-                line = line.replace(/\s*;.*/g, '').trim();
+                const originalLine = line;
+                /**
+                 * line = 'G0X10 ; comment text'
+                 * parts = ['G0X10 ', ' comment text', '']
+                 */
+                const parts = originalLine.split(/;(.*)/s); // `s` is the modifier for single-line mode
+                line = ensureString(parts[0]).trim();
                 context = this.populateContext(context);
 
                 if (line[0] === '%') {
@@ -373,30 +381,30 @@ class MarlinController {
                 // M109 Set extruder temperature and wait for the target temperature to be reached
                 if (_.includes(words, 'M109')) {
                     log.debug(`Wait for extruder temperature to reach target temperature (${line})`);
-                    this.feeder.hold({ data: 'M109' }); // Hold reason
+                    this.feeder.hold({ data: 'M109', msg: originalLine }); // Hold reason
                 }
 
                 // M190 Set heated bed temperature and wait for the target temperature to be reached
                 if (_.includes(words, 'M190')) {
                     log.debug(`Wait for heated bed temperature to reach target temperature (${line})`);
-                    this.feeder.hold({ data: 'M190' }); // Hold reason
+                    this.feeder.hold({ data: 'M190', msg: originalLine }); // Hold reason
                 }
 
                 { // Program Mode: M0, M1
                     const programMode = _.intersection(words, ['M0', 'M1'])[0];
                     if (programMode === 'M0') {
                         log.debug('M0 Program Pause');
-                        this.feeder.hold({ data: 'M0' }); // Hold reason
+                        this.feeder.hold({ data: 'M0', msg: originalLine }); // Hold reason
                     } else if (programMode === 'M1') {
                         log.debug('M1 Program Pause');
-                        this.feeder.hold({ data: 'M1' }); // Hold reason
+                        this.feeder.hold({ data: 'M1', msg: originalLine }); // Hold reason
                     }
                 }
 
                 // M6 Tool Change
                 if (_.includes(words, 'M6')) {
                     log.debug('M6 Tool Change');
-                    this.feeder.hold({ data: 'M6' }); // Hold reason
+                    this.feeder.hold({ data: 'M6', msg: originalLine }); // Hold reason
                 }
 
                 return line;
@@ -435,8 +443,13 @@ class MarlinController {
         // Sender
         this.sender = new Sender(SP_TYPE_SEND_RESPONSE, {
             dataFilter: (line, context) => {
-                // Remove comments that start with a semicolon `;`
-                line = line.replace(/\s*;.*/g, '').trim();
+                const originalLine = line;
+                /**
+                 * line = 'G0X10 ; comment text'
+                 * parts = ['G0X10 ', ' comment text', '']
+                 */
+                const parts = originalLine.split(/;(.*)/s); // `s` is the modifier for single-line mode
+                line = ensureString(parts[0]).trim();
                 context = this.populateContext(context);
 
                 const { sent, received } = this.sender.state;
@@ -445,7 +458,7 @@ class MarlinController {
                     // %wait
                     if (line === WAIT) {
                         log.debug(`Wait for the planner to empty: line=${sent + 1}, sent=${sent}, received=${received}`);
-                        this.sender.hold({ data: WAIT }); // Hold reason
+                        this.sender.hold({ data: WAIT, msg: originalLine }); // Hold reason
 
                         // G4 [P<time in ms>] [S<time in sec>]
                         // If both S and P are included, S takes precedence.
@@ -467,14 +480,14 @@ class MarlinController {
                 // M109 Set extruder temperature and wait for the target temperature to be reached
                 if (_.includes(words, 'M109')) {
                     log.debug(`Wait for extruder temperature to reach target temperature (${line}): line=${sent + 1}, sent=${sent}, received=${received}`);
-                    const reason = { data: 'M109' };
+                    const reason = { data: 'M109', msg: originalLine };
                     this.sender.hold(reason); // Hold reason
                 }
 
                 // M190 Set heated bed temperature and wait for the target temperature to be reached
                 if (_.includes(words, 'M190')) {
                     log.debug(`Wait for heated bed temperature to reach target temperature (${line}): line=${sent + 1}, sent=${sent}, received=${received}`);
-                    const reason = { data: 'M190' };
+                    const reason = { data: 'M190', msg: originalLine };
                     this.sender.hold(reason); // Hold reason
                 }
 
@@ -482,17 +495,17 @@ class MarlinController {
                     const programMode = _.intersection(words, ['M0', 'M1'])[0];
                     if (programMode === 'M0') {
                         log.debug(`M0 Program Pause: line=${sent + 1}, sent=${sent}, received=${received}`);
-                        this.workflow.pause({ data: 'M0' });
+                        this.workflow.pause({ data: 'M0', msg: originalLine });
                     } else if (programMode === 'M1') {
                         log.debug(`M1 Program Pause: line=${sent + 1}, sent=${sent}, received=${received}`);
-                        this.workflow.pause({ data: 'M1' });
+                        this.workflow.pause({ data: 'M1', msg: originalLine });
                     }
                 }
 
                 // M6 Tool Change
                 if (_.includes(words, 'M6')) {
                     log.debug(`M6 Tool Change: line=${sent + 1}, sent=${sent}, received=${received}`);
-                    this.workflow.pause({ data: 'M6' });
+                    this.workflow.pause({ data: 'M6', msg: originalLine });
                 }
 
                 return line;
@@ -677,7 +690,7 @@ class MarlinController {
                 this.emit('serialport:read', res.raw);
 
                 if (pauseError) {
-                    this.workflow.pause({ err: res.raw });
+                    this.workflow.pause({ err: true, msg: res.raw });
                 }
 
                 this.sender.ack();

--- a/src/server/controllers/Marlin/MarlinController.js
+++ b/src/server/controllers/Marlin/MarlinController.js
@@ -480,15 +480,13 @@ class MarlinController {
                 // M109 Set extruder temperature and wait for the target temperature to be reached
                 if (_.includes(words, 'M109')) {
                     log.debug(`Wait for extruder temperature to reach target temperature (${line}): line=${sent + 1}, sent=${sent}, received=${received}`);
-                    const reason = { data: 'M109', msg: originalLine };
-                    this.sender.hold(reason); // Hold reason
+                    this.sender.hold({ data: 'M109', msg: originalLine }); // Hold reason
                 }
 
                 // M190 Set heated bed temperature and wait for the target temperature to be reached
                 if (_.includes(words, 'M190')) {
                     log.debug(`Wait for heated bed temperature to reach target temperature (${line}): line=${sent + 1}, sent=${sent}, received=${received}`);
-                    const reason = { data: 'M190', msg: originalLine };
-                    this.sender.hold(reason); // Hold reason
+                    this.sender.hold({ data: 'M190', msg: originalLine }); // Hold reason
                 }
 
                 { // Program Mode: M0, M1

--- a/src/server/controllers/Smoothie/SmoothieController.js
+++ b/src/server/controllers/Smoothie/SmoothieController.js
@@ -1,4 +1,7 @@
-import ensureArray from 'ensure-array';
+import {
+    ensureArray,
+    ensureString,
+} from 'ensure-type';
 import * as parser from 'gcode-parser';
 import _ from 'lodash';
 import SerialConnection from '../../lib/SerialConnection';
@@ -162,8 +165,13 @@ class SmoothieController {
         // Feeder
         this.feeder = new Feeder({
             dataFilter: (line, context) => {
-                // Remove comments that start with a semicolon `;`
-                line = line.replace(/\s*;.*/g, '').trim();
+                const originalLine = line;
+                /**
+                 * line = 'G0X10 ; comment text'
+                 * parts = ['G0X10 ', ' comment text', '']
+                 */
+                const parts = originalLine.split(/;(.*)/s); // `s` is the modifier for single-line mode
+                line = ensureString(parts[0]).trim();
                 context = this.populateContext(context);
 
                 if (line[0] === '%') {
@@ -189,17 +197,17 @@ class SmoothieController {
                     const programMode = _.intersection(words, ['M0', 'M1'])[0];
                     if (programMode === 'M0') {
                         log.debug('M0 Program Pause');
-                        this.feeder.hold({ data: 'M0' }); // Hold reason
+                        this.feeder.hold({ data: 'M0', msg: originalLine }); // Hold reason
                     } else if (programMode === 'M1') {
                         log.debug('M1 Program Pause');
-                        this.feeder.hold({ data: 'M1' }); // Hold reason
+                        this.feeder.hold({ data: 'M1', msg: originalLine }); // Hold reason
                     }
                 }
 
                 // M6 Tool Change
                 if (_.includes(words, 'M6')) {
                     log.debug('M6 Tool Change');
-                    this.feeder.hold({ data: 'M6' }); // Hold reason
+                    this.feeder.hold({ data: 'M6', msg: originalLine }); // Hold reason
                 }
 
                 return line;
@@ -238,8 +246,13 @@ class SmoothieController {
             // Deduct the buffer size to prevent from buffer overrun
             bufferSize: (128 - 8), // The default buffer size is 128 bytes
             dataFilter: (line, context) => {
-                // Remove comments that start with a semicolon `;`
-                line = line.replace(/\s*;.*/g, '').trim();
+                const originalLine = line;
+                /**
+                 * line = 'G0X10 ; comment text'
+                 * parts = ['G0X10 ', ' comment text', '']
+                 */
+                const parts = originalLine.split(/;(.*)/s); // `s` is the modifier for single-line mode
+                line = ensureString(parts[0]).trim();
                 context = this.populateContext(context);
 
                 const { sent, received } = this.sender.state;
@@ -248,7 +261,7 @@ class SmoothieController {
                     // %wait
                     if (line === WAIT) {
                         log.debug(`Wait for the planner to empty: line=${sent + 1}, sent=${sent}, received=${received}`);
-                        this.sender.hold({ data: WAIT }); // Hold reason
+                        this.sender.hold({ data: WAIT, msg: originalLine }); // Hold reason
                         return 'G4 P0.5'; // dwell
                     }
 
@@ -268,17 +281,17 @@ class SmoothieController {
                     const programMode = _.intersection(words, ['M0', 'M1'])[0];
                     if (programMode === 'M0') {
                         log.debug(`M0 Program Pause: line=${sent + 1}, sent=${sent}, received=${received}`);
-                        this.workflow.pause({ data: 'M0' });
+                        this.workflow.pause({ data: 'M0', msg: originalLine });
                     } else if (programMode === 'M1') {
                         log.debug(`M1 Program Pause: line=${sent + 1}, sent=${sent}, received=${received}`);
-                        this.workflow.pause({ data: 'M1' });
+                        this.workflow.pause({ data: 'M1', msg: originalLine });
                     }
                 }
 
                 // M6 Tool Change
                 if (_.includes(words, 'M6')) {
                     log.debug(`M6 Tool Change: line=${sent + 1}, sent=${sent}, received=${received}`);
-                    this.workflow.pause({ data: 'M6' });
+                    this.workflow.pause({ data: 'M6', msg: originalLine });
                 }
 
                 return line;
@@ -436,7 +449,7 @@ class SmoothieController {
                 this.emit('serialport:read', res.raw);
 
                 if (pauseError) {
-                    this.workflow.pause({ err: res.raw });
+                    this.workflow.pause({ err: true, msg: res.raw });
                 }
 
                 this.sender.ack();

--- a/src/server/controllers/TinyG/TinyGController.js
+++ b/src/server/controllers/TinyG/TinyGController.js
@@ -1,4 +1,7 @@
-import ensureArray from 'ensure-array';
+import {
+    ensureArray,
+    ensureString,
+} from 'ensure-type';
 import * as parser from 'gcode-parser';
 import _ from 'lodash';
 import SerialConnection from '../../lib/SerialConnection';
@@ -194,17 +197,22 @@ class TinyGController {
 
         // Feeder
         this.feeder = new Feeder({
+            // https://github.com/synthetos/g2/wiki/JSON-Active-Comments
             dataFilter: (line, context) => {
-                // Remove comments that start with a semicolon `;`
-                // @see https://github.com/synthetos/g2/wiki/JSON-Active-Comments
-                line = line.replace(/\s*;.*/g, '').trim();
+                const originalLine = line;
+                /**
+                 * line = 'G0X10 ; comment text'
+                 * parts = ['G0X10 ', ' comment text', '']
+                 */
+                const parts = originalLine.split(/;(.*)/s); // `s` is the modifier for single-line mode
+                line = ensureString(parts[0]).trim();
                 context = this.populateContext(context);
 
                 if (line[0] === '%') {
                     // %wait
                     if (line === WAIT) {
                         log.debug('Wait for the planner to empty');
-                        this.feeder.hold({ data: WAIT }); // Hold reason
+                        this.feeder.hold({ data: WAIT, msg: originalLine }); // Hold reason
                         return 'G4 P0.5'; // dwell
                     }
 
@@ -224,17 +232,17 @@ class TinyGController {
                     const programMode = _.intersection(words, ['M0', 'M1'])[0];
                     if (programMode === 'M0') {
                         log.debug('M0 Program Pause');
-                        this.feeder.hold({ data: 'M0' }); // Hold reason
+                        this.feeder.hold({ data: 'M0', msg: originalLine }); // Hold reason
                     } else if (programMode === 'M1') {
                         log.debug('M1 Program Pause');
-                        this.feeder.hold({ data: 'M1' }); // Hold reason
+                        this.feeder.hold({ data: 'M1', msg: originalLine }); // Hold reason
                     }
                 }
 
                 // M6 Tool Change
                 if (_.includes(words, 'M6')) {
                     log.debug('M6 Tool Change');
-                    this.feeder.hold({ data: 'M6' }); // Hold reason
+                    this.feeder.hold({ data: 'M6', msg: originalLine }); // Hold reason
                 }
 
                 return line;
@@ -270,10 +278,15 @@ class TinyGController {
 
         // Sender
         this.sender = new Sender(SP_TYPE_SEND_RESPONSE, {
+            // https://github.com/synthetos/g2/wiki/JSON-Active-Comments
             dataFilter: (line, context) => {
-                // Remove comments that start with a semicolon `;`
-                // @see https://github.com/synthetos/g2/wiki/JSON-Active-Comments
-                line = line.replace(/\s*;.*/g, '').trim();
+                const originalLine = line;
+                /**
+                 * line = 'G0X10 ; comment text'
+                 * parts = ['G0X10 ', ' comment text', '']
+                 */
+                const parts = originalLine.split(/;(.*)/s); // `s` is the modifier for single-line mode
+                line = ensureString(parts[0]).trim();
                 context = this.populateContext(context);
 
                 const { sent, received } = this.sender.state;
@@ -282,7 +295,7 @@ class TinyGController {
                     // %wait
                     if (line === WAIT) {
                         log.debug(`Wait for the planner to empty: line=${sent + 1}, sent=${sent}, received=${received}`);
-                        this.sender.hold({ data: WAIT }); // Hold reason
+                        this.sender.hold({ data: WAIT, msg: originalLine }); // Hold reason
                         return 'G4 P0.5'; // dwell
                     }
 
@@ -302,17 +315,17 @@ class TinyGController {
                     const programMode = _.intersection(words, ['M0', 'M1'])[0];
                     if (programMode === 'M0') {
                         log.debug(`M0 Program Pause: line=${sent + 1}, sent=${sent}, received=${received}`);
-                        this.workflow.pause({ data: 'M0' });
+                        this.workflow.pause({ data: 'M0', msg: originalLine });
                     } else if (programMode === 'M1') {
                         log.debug(`M1 Program Pause: line=${sent + 1}, sent=${sent}, received=${received}`);
-                        this.workflow.pause({ data: 'M1' });
+                        this.workflow.pause({ data: 'M1', msg: originalLine });
                     }
                 }
 
                 // M6 Tool Change
                 if (_.includes(words, 'M6')) {
                     log.debug(`M6 Tool Change: line=${sent + 1}, sent=${sent}, received=${received}`);
-                    this.workflow.pause({ data: 'M6' });
+                    this.workflow.pause({ data: 'M6', msg: originalLine });
                 }
 
                 return line;
@@ -571,7 +584,7 @@ class TinyGController {
                     });
 
                     if (pauseError) {
-                        this.workflow.pause({ err: err.msg });
+                        this.workflow.pause({ err: true, msg: err.msg });
                     }
 
                     return;


### PR DESCRIPTION
Capture any line comment (everything after a semicolon) on an M0, M1
or M6 command and display is as part of the pause dialog in the UI.

Fixes #467.