### PR TITLE
Fix Marlin widget title

### DIFF
--- a/src/app/widgets/Marlin/Controller.jsx
+++ b/src/app/widgets/Marlin/Controller.jsx
@@ -16,7 +16,7 @@ const Controller = (props) => {
         <Modal disableOverlay size="lg" onClose={actions.closeModal}>
             <Modal.Header>
                 <Modal.Title>
-                    Grbl
+                    Marlin
                 </Modal.Title>
             </Modal.Header>
             <Modal.Body>


### PR DESCRIPTION
This PR fixes the title for the Marlin widget, changing it to "Marlin" instead of "Grbl"