### PR TITLE
TinyG with ShuttleXpress: clear queue when zone=0

### DIFF
--- a/package.json
+++ b/package.json
@@ -275,7 +275,8 @@
     "watch": "~1.0.2",
     "webappengine": "~1.2.0",
     "winston": "~3.2.1",
-    "xterm": "~3.0.2"
+    "xterm": "~3.0.2",
+    "yarn": "^1.22.17"
   },
   "devDependencies": {
     "@babel/cli": "~7.4.3",

--- a/src/app/store/defaultState.js
+++ b/src/app/store/defaultState.js
@@ -16,24 +16,33 @@ const defaultState = {
             primary: {
                 show: true,
                 widgets: [
-                    'connection', 'console', 'grbl', 'marlin', 'smoothie', 'tinyg', 'webcam'
+                    'gcode', 'connection', 'console', 'tinyg'
                 ]
             },
             secondary: {
                 show: true,
                 widgets: [
-                    'axes', 'gcode', 'macro', 'probe', 'spindle', 'laser'
+                    'axes', 'spindle', 'probe', 'macro'
                 ]
             }
         },
         machineProfile: {
-            id: null
+            id: '2e113b35-1073-4de4-b564-b807b945d80d',
+            name: 'ideas-3040',
+            limits: {
+                xmin: 0,
+                xmax: 299,
+                ymin: 0,
+                ymax: 399,
+                zmin: 1,
+                zmax: 80
+            }
         }
     },
     widgets: {
         axes: {
             minimized: false,
-            axes: ['x', 'y', 'z'],
+            axes: ['x', 'y', 'z', 'a'],
             jog: {
                 keypad: false,
                 imperial: {
@@ -42,7 +51,12 @@ const defaultState = {
                 },
                 metric: {
                     step: METRIC_STEPS.indexOf(1), // Defaults to 1 mm
-                    distances: []
+                    distances: [
+                        0.01,
+                        0.1,
+                        1,
+                        10
+                    ]
                 }
             },
             mdi: {
@@ -50,17 +64,17 @@ const defaultState = {
             },
             shuttle: {
                 feedrateMin: 500,
-                feedrateMax: 2000,
+                feedrateMax: 2500,
                 hertz: 10,
                 overshoot: 1
             }
         },
         connection: {
-            minimized: false,
+            minimized: true,
             controller: {
-                type: 'Grbl' // Grbl|Marlin|Smoothie|TinyG
+                type: 'TinyG' // Grbl|Marlin|Smoothie|TinyG
             },
-            port: '', // will be deprecated in v2
+            port: '/dev/ttyACM0', // will be deprecated in v2
             baudrate: 115200, // will be deprecated in v2
             connection: {
                 type: 'serial',
@@ -161,7 +175,7 @@ const defaultState = {
         },
         spindle: {
             minimized: false,
-            speed: 1000
+            speed: 10000
         },
         tinyg: {
             minimized: false,
@@ -186,7 +200,7 @@ const defaultState = {
             // 3D View
             disabled: false,
             projection: 'orthographic', // 'perspective' or 'orthographic'
-            cameraMode: 'pan', // 'pan' or 'rotate'
+            cameraMode: 'rotate', // 'pan' or 'rotate'
             gcode: {
                 displayName: true
             },

--- a/src/app/widgets/Axes/ShuttleControl.js
+++ b/src/app/widgets/Axes/ShuttleControl.js
@@ -2,13 +2,10 @@ import _ from 'lodash';
 import events from 'events';
 
 const HERTZ_LIMIT = 60; // 60 items per second
-//const FLUSH_INTERVAL = 250; // milliseconds
+const FLUSH_INTERVAL = 250; // milliseconds
 
-//removing need for flushing by creating large enough queue
-// to make cnc keep moving, not pause when jogging.
-
-//const QUEUE_LENGTH = Math.floor(HERTZ_LIMIT / (1000 / FLUSH_INTERVAL));
-const QUEUE_LENGTH = 30
+const QUEUE_LENGTH = Math.floor(4 * HERTZ_LIMIT / (1000 / FLUSH_INTERVAL));
+//const QUEUE_LENGTH = 30
 
 const DEFAULT_FEEDRATE_MIN = 500;
 const DEFAULT_FEEDRATE_MAX = 1500;
@@ -51,18 +48,18 @@ class ShuttleControl extends events.EventEmitter {
             relativeDistance: relativeDistance
         });
 
-        // if (!this.timer) {
-        //     this.timer = setTimeout(() => {
-        //         this.flush();
-        //     }, FLUSH_INTERVAL);
-        // }
+        if (!this.timer) {
+            this.timer = setTimeout(() => {
+                this.flush();
+            }, FLUSH_INTERVAL);
+        }
     }
 
     clear() {
-        // if (this.timer) {
-        //     clearTimeout(this.timer);
-        //     this.timer = null;
-        // }
+        if (this.timer) {
+            clearTimeout(this.timer);
+            this.timer = null;
+        }
         this.queue = [];
     }
 
@@ -77,8 +74,8 @@ class ShuttleControl extends events.EventEmitter {
             relativeDistance: _.sumBy(this.queue, (o) => o.relativeDistance)
         };
 
-        //clearTimeout(this.timer);
-        //this.timer = null;
+        clearTimeout(this.timer);
+        this.timer = null;
         this.queue = [];
         this.emit('flush', accumulatedResult);
         typeof callback === 'function' && callback(accumulatedResult);

--- a/src/app/widgets/Axes/index.jsx
+++ b/src/app/widgets/Axes/index.jsx
@@ -385,6 +385,12 @@ class AxesWidget extends PureComponent {
                 this.shuttleControl.clear();
 
                 if (jog.axis) {
+                    //TinyG keeps moving for a second, when done jogging, if queue isn't cleared
+                    //  (Unsure if this applies to other firmwares) --@Sil3ntlight
+                    if (type === TINYG) {
+                        controller.command('gcode', '!%'); // TinyG / g2core command used to stop jogging, ! is feedhold, % is queue flush and resume
+                                                           //   see also: https://github.com/synthetos/g2/wiki/Feedhold,-Resume,-and-Other-Simple-Commands#jogging-using-feedhold-and-queue-flush
+                    }
                     controller.command('gcode', 'G90');
                 }
                 return;

--- a/src/app/widgets/Axes/index.jsx
+++ b/src/app/widgets/Axes/index.jsx
@@ -117,10 +117,9 @@ class AxesWidget extends PureComponent {
 
             if (units === IMPERIAL_UNITS) {
                 const step = this.config.get('jog.imperial.step');
-                const imperialJogDistances = ensureArray(this.config.get('jog.imperial.distances', []));
+                const imperialJogDistances = ensureArray(this.config.get('jog.imperial.distances', ...IMPERIAL_STEPS));
                 const imperialJogSteps = [
-                    ...imperialJogDistances,
-                    ...IMPERIAL_STEPS
+                    ...imperialJogDistances
                 ];
                 const distance = Number(imperialJogSteps[step]) || 0;
                 return distance;
@@ -128,10 +127,9 @@ class AxesWidget extends PureComponent {
 
             if (units === METRIC_UNITS) {
                 const step = this.config.get('jog.metric.step');
-                const metricJogDistances = ensureArray(this.config.get('jog.metric.distances', []));
+                const metricJogDistances = ensureArray(this.config.get('jog.metric.distances', ...METRIC_STEPS));
                 const metricJogSteps = [
-                    ...metricJogDistances,
-                    ...METRIC_STEPS
+                    ...metricJogDistances
                 ];
                 const distance = Number(metricJogSteps[step]) || 0;
                 return distance;
@@ -231,12 +229,10 @@ class AxesWidget extends PureComponent {
         stepForward: () => {
             this.setState(state => {
                 const imperialJogSteps = [
-                    ...state.jog.imperial.distances,
-                    ...IMPERIAL_STEPS
+                    ...state.jog.imperial.distances
                 ];
                 const metricJogSteps = [
-                    ...state.jog.metric.distances,
-                    ...METRIC_STEPS
+                    ...state.jog.metric.distances
                 ];
 
                 return {
@@ -261,12 +257,10 @@ class AxesWidget extends PureComponent {
         stepBackward: () => {
             this.setState(state => {
                 const imperialJogSteps = [
-                    ...state.jog.imperial.distances,
-                    ...IMPERIAL_STEPS
+                    ...state.jog.imperial.distances
                 ];
                 const metricJogSteps = [
-                    ...state.jog.metric.distances,
-                    ...METRIC_STEPS
+                    ...state.jog.metric.distances
                 ];
 
                 return {
@@ -291,12 +285,10 @@ class AxesWidget extends PureComponent {
         stepNext: () => {
             this.setState(state => {
                 const imperialJogSteps = [
-                    ...state.jog.imperial.distances,
-                    ...IMPERIAL_STEPS
+                    ...state.jog.imperial.distances
                 ];
                 const metricJogSteps = [
-                    ...state.jog.metric.distances,
-                    ...METRIC_STEPS
+                    ...state.jog.metric.distances
                 ];
 
                 return {
@@ -684,11 +676,11 @@ class AxesWidget extends PureComponent {
                 keypad: this.config.get('jog.keypad'),
                 imperial: {
                     step: this.config.get('jog.imperial.step'),
-                    distances: ensureArray(this.config.get('jog.imperial.distances', []))
+                    distances: ensureArray(this.config.get('jog.imperial.distances', ...IMPERIAL_STEPS))
                 },
                 metric: {
                     step: this.config.get('jog.metric.step'),
-                    distances: ensureArray(this.config.get('jog.metric.distances', []))
+                    distances: ensureArray(this.config.get('jog.metric.distances', ...IMPERIAL_STEPS))
                 }
             },
             mdi: {
@@ -921,8 +913,8 @@ class AxesWidget extends PureComponent {
                             config={config}
                             onSave={() => {
                                 const axes = config.get('axes', DEFAULT_AXES);
-                                const imperialJogDistances = ensureArray(config.get('jog.imperial.distances', []));
-                                const metricJogDistances = ensureArray(config.get('jog.metric.distances', []));
+                                const imperialJogDistances = ensureArray(config.get('jog.imperial.distances', ...IMPERIAL_STEPS));
+                                const metricJogDistances = ensureArray(config.get('jog.metric.distances', ...METRIC_STEPS));
 
                                 this.setState(state => ({
                                     axes: axes,


### PR DESCRIPTION
(Unsure if applies to firmwares other than TinyG / g2core, so only implemented for tinyg/g2core)

When jogging with shuttleXpress (any OS, browser or desktop, etc), it has a delay of 1-2 seconds when returning the wheel to center. This makes overshooting and crashing difficult to avoid.

TinyG and g2core require a feedhold command combined with a queue flush when done sending continuous jogging commands, as per:
[https://github.com/synthetos/g2/wiki/Feedhold,-Resume,-and-Other-Simple-Commands#jogging-using-feedhold-and-queue-flush](https://github.com/synthetos/g2/wiki/Feedhold,-Resume,-and-Other-Simple-Commands#jogging-using-feedhold-and-queue-flush)

This applies the same to TinyG and g2core both. 
Note that the ! and % should not have a space between, otherwise it will only feedhold (this is intentional in g2core, as some gcode generators use % as a comment delimiter)
