### PR TITLE
fix: fix wrong `pre-push` hook in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -348,7 +348,7 @@
     "write-file-webpack-plugin": "~4.5.0"
   },
   "pre-push": [
-    "eslint:debug"
+    "eslint-debug"
   ],
   "collective": {
     "type": "opencollective",


### PR DESCRIPTION
Pre-push was set to `eslint:debug` but defined script is using `eslint-debug`