### PR TITLE
Grbl: Fix for missing alarm state for non `<Alarm|...>` lines (like soft limits)

### DIFF
--- a/src/server/controllers/Grbl/GrblRunner.js
+++ b/src/server/controllers/Grbl/GrblRunner.js
@@ -120,6 +120,20 @@ class GrblRunner extends events.EventEmitter {
             return;
         }
         if (type === GrblLineParserResultAlarm) {
+            const alarmPayload = {
+                activeState: GRBL_ACTIVE_STATE_ALARM
+            };
+            const nextState = {
+                ...this.state,
+                status: {
+                    ...this.state.status,
+                    ...alarmPayload
+                }
+            };
+            if (!_.isEqual(this.state.status, nextState.status)) {
+                this.state = nextState; // enforce change
+            }
+            this.emit('status', alarmPayload);
             this.emit('alarm', payload);
             return;
         }

--- a/src/server/controllers/Grbl/GrblRunner.js
+++ b/src/server/controllers/Grbl/GrblRunner.js
@@ -133,7 +133,6 @@ class GrblRunner extends events.EventEmitter {
             if (!_.isEqual(this.state.status, nextState.status)) {
                 this.state = nextState; // enforce change
             }
-            this.emit('status', alarmPayload);
             this.emit('alarm', payload);
             return;
         }

--- a/test/grbl.js
+++ b/test/grbl.js
@@ -147,8 +147,8 @@ test('GrblLineParserResultAlarm', (t) => {
 
 test('GrblLineParserResultAlarm: sets activeState', (t) => {
     const runner = new GrblRunner();
-    runner.on('status', ({ activeState }) => {
-        t.equal(activeState, 'Alarm');
+    runner.on('alarm', () => {
+        t.equal(runner.state.status.activeState, 'Alarm');
         t.end();
     });
 

--- a/test/grbl.js
+++ b/test/grbl.js
@@ -145,6 +145,17 @@ test('GrblLineParserResultAlarm', (t) => {
     runner.parse(line);
 });
 
+test('GrblLineParserResultAlarm: sets activeState', (t) => {
+    const runner = new GrblRunner();
+    runner.on('status', ({ activeState }) => {
+        t.equal(activeState, 'Alarm');
+        t.end();
+    });
+
+    const line = 'ALARM:2';
+    runner.parse(line);
+});
+
 test('GrblLineParserResultParserState', (t) => {
     t.test('#1', (t) => {
         const runner = new GrblRunner();


### PR DESCRIPTION
This is a fix for https://github.com/cncjs/cncjs/issues/596 

Soft limit alarms aren't handled by the `GrblLineParserResultStatus` module, because they don't match the [`<State|...>` regex](https://github.com/cncjs/cncjs/blob/master/src/server/controllers/Grbl/GrblLineParserResultStatus.js#L19))

This causes cncjs to be in a half-broken idle state, where there is no visible indication that something's gone wrong. This is especially true if the UI was closed during the alarm event (or reloaded after), so that the alarm message will not appear in the serial console.

## Before

![Triggering soft limit alarm, Grbl state is idle until reset button pressed](https://user-images.githubusercontent.com/242008/81432105-ecc05080-9127-11ea-9019-b1df4a955c4c.gif)

## After

![Triggering soft limit alarm, Grbl state becomes Alarm immediately and remains after a page reload](https://user-images.githubusercontent.com/242008/170887591-92a4a7e1-3115-4dca-9796-65500abeeed6.gif)

