### PR TITLE
feat: display the G-code line of certain M commands (e.g. M0/M1/M6/...) in the toast notification

### DIFF
--- a/src/app/widgets/Visualizer/Notifications.js
+++ b/src/app/widgets/Visualizer/Notifications.js
@@ -44,36 +44,54 @@ const Notifications = ({ show, type, data, onDismiss, style, ...props }) => (
             {type === NOTIFICATION_PROGRAM_ERROR && (
                 <div>
                     <div><strong>{i18n._('Error')}</strong></div>
+                    {data && (
+                        <code>{data}</code>
+                    )}
                     <div>{i18n._('Click the Resume button to resume program execution.')}</div>
                 </div>
             )}
             {type === NOTIFICATION_M0_PROGRAM_PAUSE && (
                 <div>
                     <div><strong>{i18n._('M0 Program Pause')}</strong></div>
+                    {data && (
+                        <code>{data}</code>
+                    )}
                     <div>{i18n._('Click the Resume button to resume program execution.')}</div>
                 </div>
             )}
             {type === NOTIFICATION_M1_PROGRAM_PAUSE && (
                 <div>
                     <div><strong>{i18n._('M1 Program Pause')}</strong></div>
+                    {data && (
+                        <code>{data}</code>
+                    )}
                     <div>{i18n._('Click the Resume button to resume program execution.')}</div>
                 </div>
             )}
             {type === NOTIFICATION_M2_PROGRAM_END && (
                 <div>
                     <div><strong>{i18n._('M2 Program End')}</strong></div>
+                    {data && (
+                        <code>{data}</code>
+                    )}
                     <div>{i18n._('Click the Stop button to stop program execution.')}</div>
                 </div>
             )}
             {type === NOTIFICATION_M30_PROGRAM_END && (
                 <div>
                     <div><strong>{i18n._('M30 Program End')}</strong></div>
+                    {data && (
+                        <code>{data}</code>
+                    )}
                     <div>{i18n._('Click the Stop button to stop program execution.')}</div>
                 </div>
             )}
             {type === NOTIFICATION_M6_TOOL_CHANGE && (
                 <div>
                     <div><strong>{i18n._('M6 Tool Change')}</strong></div>
+                    {data && (
+                        <code>{data}</code>
+                    )}
                     <div>
                         {i18n._('Run a tool change macro to change the tool and adjust the Z-axis offset. Afterwards, click the Resume button to resume program execution.')}
                         <Space width="4" />
@@ -89,12 +107,18 @@ const Notifications = ({ show, type, data, onDismiss, style, ...props }) => (
             {type === NOTIFICATION_M109_SET_EXTRUDER_TEMPERATURE && (
                 <div>
                     <div><strong>{i18n._('M109 Set Extruder Temperature')}</strong></div>
+                    {data && (
+                        <code>{data}</code>
+                    )}
                     <div>{i18n._('Waiting for the target temperature to be reached...')}</div>
                 </div>
             )}
             {type === NOTIFICATION_M190_SET_HEATED_BED_TEMPERATURE && (
                 <div>
                     <div><strong>{i18n._('M190 Set Heated Bed Temperature')}</strong></div>
+                    {data && (
+                        <code>{data}</code>
+                    )}
                     <div>{i18n._('Waiting for the target temperature to be reached...')}</div>
                 </div>
             )}

--- a/src/app/widgets/Visualizer/index.jsx
+++ b/src/app/widgets/Visualizer/index.jsx
@@ -618,32 +618,39 @@ class VisualizerWidget extends PureComponent {
             };
 
             if (hold) {
-                const { err, data } = { ...holdReason };
+                const { err, data, msg } = { ...holdReason };
 
                 if (err) {
                     notification.type = NOTIFICATION_PROGRAM_ERROR;
-                    notification.data = err;
+                    notification.data = msg;
                 } else if (data === 'M0') {
                     // M0 Program Pause
                     notification.type = NOTIFICATION_M0_PROGRAM_PAUSE;
+                    notification.data = msg;
                 } else if (data === 'M1') {
                     // M1 Program Pause
                     notification.type = NOTIFICATION_M1_PROGRAM_PAUSE;
+                    notification.data = msg;
                 } else if (data === 'M2') {
                     // M2 Program End
                     notification.type = NOTIFICATION_M2_PROGRAM_END;
+                    notification.data = msg;
                 } else if (data === 'M30') {
                     // M30 Program End
                     notification.type = NOTIFICATION_M30_PROGRAM_END;
+                    notification.data = msg;
                 } else if (data === 'M6') {
                     // M6 Tool Change
                     notification.type = NOTIFICATION_M6_TOOL_CHANGE;
+                    notification.data = msg;
                 } else if (data === 'M109') {
                     // M109 Set Extruder Temperature
                     notification.type = NOTIFICATION_M109_SET_EXTRUDER_TEMPERATURE;
+                    notification.data = msg;
                 } else if (data === 'M190') {
                     // M190 Set Heated Bed Temperature
                     notification.type = NOTIFICATION_M190_SET_HEATED_BED_TEMPERATURE;
+                    notification.data = msg;
                 }
             }
 


### PR DESCRIPTION
```nc
M1 (this is a test)
```

![image](https://user-images.githubusercontent.com/447801/174854673-e4b309e6-1e97-4475-9f4f-695c5234e54a.png)
