### PR TITLE
feat: add support for new Marlin 2.0 temperature report format

### DIFF
--- a/src/server/controllers/Marlin/MarlinLineParserResultTemperature.js
+++ b/src/server/controllers/Marlin/MarlinLineParserResultTemperature.js
@@ -5,11 +5,13 @@ class MarlinLineParserResultTemperature {
     // ok T:293.0 /0.0 (0.0) B:25.9 /0.0 T0:293.0 /0.0 (0.0) T1:100.0 /0.0 (0.0) @:0 B@:0 @0:0 @1:0
     // ok T:293.0 /0.0 (0.0) B:25.9 /0.0 T0:293.0 /0.0 (0.0) T1:100.0 /0.0 (0.0) @:0 B@:0 @0:0 @1:0 W:?
     // ok T:293.0 /0.0 (0.0) B:25.9 /0.0 T0:293.0 /0.0 (0.0) T1:100.0 /0.0 (0.0) @:0 B@:0 @0:0 @1:0 W:0
+    // ok T0:27.58 /0.00 B:28.27 /0.00 T0:27.58 /0.00 T1:27.37 /0.00 @:0 B@:0 @0:0 @1:0
     //  T:293.0 /0.0 B:25.9 /0.0 @:0 B@:0
     //  T:293.0 /0.0 B:25.9 /0.0 T0:293.0 /0.0 T1:100.0 /0.0 @:0 B@:0 @0:0 @1:0
     //  T:293.0 /0.0 (0.0) B:25.9 /0.0 T0:293.0 /0.0 (0.0) T1:100.0 /0.0 (0.0) @:0 B@:0 @0:0 @1:0
+    //  T0:27.58 /0.00 B:28.27 /0.00 T0:27.58 /0.00 T1:27.37 /0.00 @:0 B@:0 @0:0 @1:0
     static parse(line) {
-        let r = line.match(/^(ok)?\s+T:[0-9\.\-]+/i);
+        let r = line.match(/^(ok)?\s+(T|T\d+):[0-9\.\-]+/i);
         if (!r) {
             return null;
         }
@@ -26,6 +28,12 @@ class MarlinLineParserResultTemperature {
             const key = r[1] || r[4] || r[6];
 
             if (key === 'T') { // T:293.0 /0.0
+                payload.extruder.deg = r[2];
+                payload.extruder.degTarget = r[3];
+                continue;
+            }
+
+            if (key === 'T0') { // T0:27.58 /0.00
                 payload.extruder.deg = r[2];
                 payload.extruder.degTarget = r[3];
                 continue;

--- a/test/marlin.js
+++ b/test/marlin.js
@@ -305,5 +305,51 @@ test('MarlinLineParserResultTemperature', (t) => {
         runner.parse(line);
     });
 
+    t.test('ok T0:27.58 /0.00 B:28.27 /0.00 T0:27.58 /0.00 T1:27.37 /0.00 @:0 B@:0 @0:0 @1:0', (t) => {
+        const runner = new MarlinRunner();
+        runner.on('temperature', ({ raw, ok, extruder, heatedBed, wait }) => {
+            t.equal(raw, 'ok T0:27.58 /0.00 B:28.27 /0.00 T0:27.58 /0.00 T1:27.37 /0.00 @:0 B@:0 @0:0 @1:0');
+            t.equal(ok, true);
+            t.same(extruder, {
+                deg: '27.58',
+                degTarget: '0.00',
+                power: 0,
+            });
+            t.same(heatedBed, {
+                deg: '28.27',
+                degTarget: '0.00',
+                power: 0,
+            });
+            t.equal(wait, undefined);
+            t.end();
+        });
+
+        const line = 'ok T0:27.58 /0.00 B:28.27 /0.00 T0:27.58 /0.00 T1:27.37 /0.00 @:0 B@:0 @0:0 @1:0';
+        runner.parse(line);
+    });
+
+    t.test(' T0:27.72 /0.00 B:28.38 /0.00 T0:27.72 /0.00 T1:27.28 /0.00 @:0 B@:0 @0:0 @1:0', (t) => {
+        const runner = new MarlinRunner();
+        runner.on('temperature', ({ raw, ok, extruder, heatedBed, wait }) => {
+            t.equal(raw, ' T0:27.72 /0.00 B:28.38 /0.00 T0:27.72 /0.00 T1:27.28 /0.00 @:0 B@:0 @0:0 @1:0');
+            t.equal(ok, false);
+            t.same(extruder, {
+                deg: '27.72',
+                degTarget: '0.00',
+                power: 0,
+            });
+            t.same(heatedBed, {
+                deg: '28.38',
+                degTarget: '0.00',
+                power: 0,
+            });
+            t.equal(wait, undefined);
+            t.end();
+        });
+
+        const line = ' T0:27.72 /0.00 B:28.38 /0.00 T0:27.72 /0.00 T1:27.28 /0.00 @:0 B@:0 @0:0 @1:0';
+        runner.parse(line);
+    });
+
     t.end();
 });


### PR DESCRIPTION
Related to https://github.com/cncjs/cncjs/issues/759 (@rflulling)

This PR adds support for Marlin 2.0 temperature report format:
```
ok T0:27.58 /0.00 B:28.27 /0.00 T0:27.58 /0.00 T1:27.37 /0.00 @:0 B@:0 @0:0 @1:0
 T0:27.72 /0.00 B:28.38 /0.00 T0:27.72 /0.00 T1:27.28 /0.00 @:0 B@:0 @0:0 @1:0
wait
wait
 T0:27.66 /0.00 B:28.30 /0.00 T0:27.66 /0.00 T1:27.28 /0.00 @:0 B@:0 @0:0 @1:0
```
