### PR TITLE
Push latest tag on tag builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,3 +118,6 @@ jobs:
             docker build -f Dockerfile -t $DOCKER_REPO:$DOCKER_BRANCH_TAG .
             docker images
             docker push $DOCKER_REPO:$DOCKER_BRANCH_TAG
+
+            docker tag $DOCKER_BRANCH_TAG latest
+            docker push $DOCKER_REPO:latest


### PR DESCRIPTION
I considered attempting to restrict this to `master` branch builds only, but it appears that `$CIRCLE_BRANCH` is empty during the `deploy-tag` job. Looks like if it's a tag build, then `$CIRCLE_TAG` is populated instead. I inspected [this run](https://app.circleci.com/pipelines/github/cncjs/cncjs/235/workflows/9e21b68c-04cc-4498-a47a-c33fb712a251/jobs/403).

Tag builds should be safe to tag as `latest`, I think.

Resolves https://github.com/cncjs/cncjs/issues/741