### PR TITLE
Fix Docker tag syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,5 +119,5 @@ jobs:
             docker images
             docker push $DOCKER_REPO:$DOCKER_BRANCH_TAG
 
-            docker tag $DOCKER_BRANCH_TAG latest
+            docker tag $DOCKER_REPO:$DOCKER_BRANCH_TAG $DOCKER_REPO:latest
             docker push $DOCKER_REPO:latest


### PR DESCRIPTION
First attempt in https://github.com/cncjs/cncjs/pull/784 was [broken](https://app.circleci.com/pipelines/github/cncjs/cncjs/237/workflows/8ff05004-b348-4103-a148-47c91f099bc6/jobs/405):

```
0ac3c0fe: Preparing 
57fd6d7d: Preparing 
0ef44274: Preparing 
2ef10e9a: Preparing 
v1.9.28: digest: sha256:0ab6d82f48cfc3bfe6faf05dcef435e7a052910679bdb0f534267d4d45b3ca0b size: 1372
Error response from daemon: No such image: v1.9.28:latest

Exited with code exit status 1
CircleCI received exit code 1
```

This should fix the `docker tag` syntax.