### PR TITLE
html5-webcam: feat: Update Webcam widget to allow streaming h264(mp4)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,13 +29,13 @@ environment:
       nodejs_version: "14"
       ARCH: x64
       # https://github.com/nodejs/node-gyp/issues/2219
-      PYTHON: "C:\Python39-x64"
+      PYTHON: "C:\\Python39-x64"
     - job_name: Windows build (x86)
       appveyor_build_worker_image: Visual Studio 2019
       nodejs_version: "14"
       ARCH: x86
       # https://github.com/nodejs/node-gyp/issues/2219
-      PYTHON: "C:\Python39"
+      PYTHON: "C:\\Python39"
   global:
     GITHUB_TOKEN:
       secure: G9Qlv8MYhgvYlUxWWUiDdfIUTrKcia16HAdzkVydWqC+wo60XrC8nk1Q2R9WKGXx
@@ -414,12 +414,13 @@ for:
       fast_finish: true
 
     init:
+      - "set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+      - python --version
       - git --version
       - git config --global core.autocrlf false
       - git config --global user.name "AppVeyor"
       - git config --global user.email "appveyor@ci.appveyor.com"
       - ps: |
-          $env:PATH="$env:PYTHON;$env:PYTHON/Scripts;$env:PATH"
           $env:CI_BRANCH = $env:APPVEYOR_REPO_BRANCH
           $env:CI_BUILD_NUMBER = $env:APPVEYOR_BUILD_NUMBER
           $env:CI_COMMIT = $env:APPVEYOR_REPO_COMMIT

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -414,13 +414,12 @@ for:
       fast_finish: true
 
     init:
-      # Since we are not using the defaut python installation here.
-      - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
       - git --version
       - git config --global core.autocrlf false
       - git config --global user.name "AppVeyor"
       - git config --global user.email "appveyor@ci.appveyor.com"
       - ps: |
+          $env:PATH="$env:PYTHON;$env:PYTHON/Scripts;$env:PATH"
           $env:CI_BRANCH = $env:APPVEYOR_REPO_BRANCH
           $env:CI_BUILD_NUMBER = $env:APPVEYOR_BUILD_NUMBER
           $env:CI_COMMIT = $env:APPVEYOR_REPO_COMMIT
@@ -434,6 +433,7 @@ for:
           Write-Host "• CI_COMMIT_SHORT=$env:CI_COMMIT_SHORT"
           Write-Host "• CI_COMMIT_TIMESTAMP=$env:CI_COMMIT_TIMESTAMP"
           Write-Host "• CI_TAG=$env:CI_TAG"
+      - python --version
 
     install:
       - ps: Install-Product node $env:nodejs_version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,27 +10,27 @@ environment:
     #  ARCH: i386
     - job_name: Linux build (amd64)
       appveyor_build_worker_image: Ubuntu2004
-      nodejs_version: "12"
+      nodejs_version: "14"
       ARCH: amd64
     - job_name: Linux build (arm)
       appveyor_build_worker_image: Ubuntu2004
-      nodejs_version: "12"
+      nodejs_version: "14"
       ARCH: arm
     - job_name: Linux build (arm64)
       appveyor_build_worker_image: Ubuntu2004
-      nodejs_version: "12"
+      nodejs_version: "14"
       ARCH: arm64
     - job_name: macOS build (x64)
       appveyor_build_worker_image: macos
-      nodejs_version: "12"
+      nodejs_version: "14"
       ARCH: x64
     - job_name: Windows build (x64)
       appveyor_build_worker_image: Visual Studio 2019
-      nodejs_version: "12"
+      nodejs_version: "14"
       ARCH: x64
     - job_name: Windows build (x86)
       appveyor_build_worker_image: Visual Studio 2019
-      nodejs_version: "12"
+      nodejs_version: "14"
       ARCH: x86
   global:
     GITHUB_TOKEN:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -433,6 +433,9 @@ for:
       - ps: Install-Product node $env:nodejs_version
       - npm config set loglevel warn
       - npm config set scripts-prepend-node-path auto
+      # Fix broken npm on Windows/node 14
+      # https://github.com/actions/setup-node/issues/623
+      - npm install -g npm@8
       - npm install -g npm
       - npm install -g yarn
       - yarn

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,10 +28,14 @@ environment:
       appveyor_build_worker_image: Visual Studio 2019
       nodejs_version: "14"
       ARCH: x64
+      # https://github.com/nodejs/node-gyp/issues/2219
+      PYTHON: "C:\Python39-x64"
     - job_name: Windows build (x86)
       appveyor_build_worker_image: Visual Studio 2019
       nodejs_version: "14"
       ARCH: x86
+      # https://github.com/nodejs/node-gyp/issues/2219
+      PYTHON: "C:\Python39"
   global:
     GITHUB_TOKEN:
       secure: G9Qlv8MYhgvYlUxWWUiDdfIUTrKcia16HAdzkVydWqC+wo60XrC8nk1Q2R9WKGXx
@@ -410,6 +414,8 @@ for:
       fast_finish: true
 
     init:
+      # Since we are not using the defaut python installation here.
+      - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
       - git --version
       - git config --global core.autocrlf false
       - git config --global user.name "AppVeyor"

--- a/src/app/i18n/cs/resource.json
+++ b/src/app/i18n/cs/resource.json
@@ -533,5 +533,5 @@
     "Show Cutting Tool": "",
     "Ready to start": "",
     "Connect to an IP camera": "",
-    "The URL must be for a Motion JPEG (mjpeg) HTTP or RTSP stream.": ""
+    "The URL must be for a Motion JPEG (mjpeg) HTTP RTSP or H264(MP4) stream.": ""
 }

--- a/src/app/i18n/de/resource.json
+++ b/src/app/i18n/de/resource.json
@@ -533,5 +533,5 @@
     "Show Cutting Tool": "",
     "Ready to start": "",
     "Connect to an IP camera": "",
-    "The URL must be for a Motion JPEG (mjpeg) HTTP or RTSP stream.": ""
+    "The URL must be for a Motion JPEG (mjpeg) HTTP RTSP or H264(MP4) stream.": ""
 }

--- a/src/app/i18n/en/resource.json
+++ b/src/app/i18n/en/resource.json
@@ -533,5 +533,5 @@
     "Show Cutting Tool": "Show Cutting Tool",
     "Ready to start": "Ready to start",
     "Connect to an IP camera": "Connect to an IP camera",
-    "The URL must be for a Motion JPEG (mjpeg) HTTP or RTSP stream.": "The URL must be for a Motion JPEG (mjpeg) HTTP or RTSP stream."
+    "The URL must be for a Motion JPEG (mjpeg) HTTP RTSP or H264(MP4) stream.": "The URL must be for a Motion JPEG (mjpeg) HTTP RTSP or H264(MP4) stream."
 }

--- a/src/app/i18n/es/resource.json
+++ b/src/app/i18n/es/resource.json
@@ -533,5 +533,5 @@
     "Show Cutting Tool": "",
     "Ready to start": "",
     "Connect to an IP camera": "",
-    "The URL must be for a Motion JPEG (mjpeg) HTTP or RTSP stream.": ""
+    "The URL must be for a Motion JPEG (mjpeg) HTTP RTSP or H264(MP4) stream.": ""
 }

--- a/src/app/i18n/fr/resource.json
+++ b/src/app/i18n/fr/resource.json
@@ -533,5 +533,5 @@
     "Show Cutting Tool": "",
     "Ready to start": "",
     "Connect to an IP camera": "",
-    "The URL must be for a Motion JPEG (mjpeg) HTTP or RTSP stream.": ""
+    "The URL must be for a Motion JPEG (mjpeg) HTTP RTSP or H264(MP4) stream.": ""
 }

--- a/src/app/i18n/hu/resource.json
+++ b/src/app/i18n/hu/resource.json
@@ -533,5 +533,5 @@
     "Show Cutting Tool": "",
     "Ready to start": "",
     "Connect to an IP camera": "",
-    "The URL must be for a Motion JPEG (mjpeg) HTTP or RTSP stream.": ""
+    "The URL must be for a Motion JPEG (mjpeg) HTTP RTSP or H264(MP4) stream.": ""
 }

--- a/src/app/i18n/it/resource.json
+++ b/src/app/i18n/it/resource.json
@@ -533,5 +533,5 @@
     "Show Cutting Tool": "",
     "Ready to start": "",
     "Connect to an IP camera": "",
-    "The URL must be for a Motion JPEG (mjpeg) HTTP or RTSP stream.": ""
+    "The URL must be for a Motion JPEG (mjpeg) HTTP RTSP or H264(MP4) stream.": ""
 }

--- a/src/app/i18n/ja/resource.json
+++ b/src/app/i18n/ja/resource.json
@@ -533,5 +533,5 @@
     "Show Cutting Tool": "工具を表示する",
     "Ready to start": "スタートの準備ができました",
     "Connect to an IP camera": "IPカメラと接続",
-    "The URL must be for a Motion JPEG (mjpeg) HTTP or RTSP stream.": "このURLはモーションJPEG (mjpeg) HTTP もしくは RTSP ストリームである必要があります。"
+    "The URL must be for a Motion JPEG (mjpeg) HTTP RTSP or H264(MP4) stream.": "このURLはモーションJPEG (mjpeg) HTTP もしくは RTSP ストリームである必要があります。"
 }

--- a/src/app/i18n/nb/resource.json
+++ b/src/app/i18n/nb/resource.json
@@ -533,5 +533,5 @@
     "Show Cutting Tool": "Vis skjæreverktøy",
     "Ready to start": "Klar til å starte",
     "Connect to an IP camera": "Koble til et IP-kamera",
-    "The URL must be for a Motion JPEG (mjpeg) HTTP or RTSP stream.": "URL-en må være til en Motion JPEG (mjpeg) HTTP- eller RTSP-strøm."
+    "The URL must be for a Motion JPEG (mjpeg) HTTP RTSP or H264(MP4) stream.": "URL-en må være til en Motion JPEG (mjpeg) HTTP RTSP- eller H264(MP4)-strøm."
 }

--- a/src/app/i18n/nl/resource.json
+++ b/src/app/i18n/nl/resource.json
@@ -533,5 +533,5 @@
     "Show Cutting Tool": "Laat gereedschap zien",
     "Ready to start": "Klaar om te starten",
     "Connect to an IP camera": "Verbind met een IP camera",
-    "The URL must be for a Motion JPEG (mjpeg) HTTP or RTSP stream.": "De URL moet voor een Motion JPEG (mjpeg), HTTP-stream of RTSP-stream zijn."
+    "The URL must be for a Motion JPEG (mjpeg) HTTP RTSP or H264(MP4) stream.": "De URL moet voor een Motion JPEG (mjpeg), HTTP-stream of RTSP-stream zijn."
 }

--- a/src/app/i18n/pt-br/resource.json
+++ b/src/app/i18n/pt-br/resource.json
@@ -533,5 +533,5 @@
     "Show Cutting Tool": "",
     "Ready to start": "",
     "Connect to an IP camera": "",
-    "The URL must be for a Motion JPEG (mjpeg) HTTP or RTSP stream.": ""
+    "The URL must be for a Motion JPEG (mjpeg) HTTP RTSP or H264(MP4) stream.": ""
 }

--- a/src/app/i18n/pt-pt/resource.json
+++ b/src/app/i18n/pt-pt/resource.json
@@ -533,5 +533,5 @@
     "Show Cutting Tool": "Mostrar Ferramenta",
     "Ready to start": "",
     "Connect to an IP camera": "Conectar a câmera IP",
-    "The URL must be for a Motion JPEG (mjpeg) HTTP or RTSP stream.": ""
+    "The URL must be for a Motion JPEG (mjpeg) HTTP RTSP or H264(MP4) stream.": ""
 }

--- a/src/app/i18n/ru/resource.json
+++ b/src/app/i18n/ru/resource.json
@@ -533,5 +533,5 @@
     "Show Cutting Tool": "",
     "Ready to start": "",
     "Connect to an IP camera": "",
-    "The URL must be for a Motion JPEG (mjpeg) HTTP or RTSP stream.": ""
+    "The URL must be for a Motion JPEG (mjpeg) HTTP RTSP or H264(MP4) stream.": ""
 }

--- a/src/app/i18n/tr/resource.json
+++ b/src/app/i18n/tr/resource.json
@@ -533,5 +533,5 @@
     "Show Cutting Tool": "",
     "Ready to start": "",
     "Connect to an IP camera": "",
-    "The URL must be for a Motion JPEG (mjpeg) HTTP or RTSP stream.": ""
+    "The URL must be for a Motion JPEG (mjpeg) HTTP RTSP or H264(MP4) stream.": ""
 }

--- a/src/app/i18n/zh-cn/resource.json
+++ b/src/app/i18n/zh-cn/resource.json
@@ -533,5 +533,5 @@
     "Show Cutting Tool": "",
     "Ready to start": "",
     "Connect to an IP camera": "",
-    "The URL must be for a Motion JPEG (mjpeg) HTTP or RTSP stream.": ""
+    "The URL must be for a Motion JPEG (mjpeg) HTTP RTSP or H264(MP4) stream.": ""
 }

--- a/src/app/i18n/zh-tw/resource.json
+++ b/src/app/i18n/zh-tw/resource.json
@@ -533,5 +533,5 @@
     "Show Cutting Tool": "",
     "Ready to start": "",
     "Connect to an IP camera": "",
-    "The URL must be for a Motion JPEG (mjpeg) HTTP or RTSP stream.": ""
+    "The URL must be for a Motion JPEG (mjpeg) HTTP RTSP or H264(MP4) stream.": ""
 }

--- a/src/app/widgets/Webcam/Settings.jsx
+++ b/src/app/widgets/Webcam/Settings.jsx
@@ -9,7 +9,7 @@ import i18n from 'app/lib/i18n';
 import log from 'app/lib/log';
 import {
     MEDIA_SOURCE_LOCAL,
-    MEDIA_SOURCE_MJPEG
+    MEDIA_SOURCE_STREAM
 } from './constants';
 
 const MutedText = styled.div`
@@ -141,10 +141,10 @@ class Settings extends PureComponent {
                                 <input
                                     type="radio"
                                     name="mediaSource"
-                                    value={MEDIA_SOURCE_MJPEG}
-                                    checked={mediaSource === MEDIA_SOURCE_MJPEG}
+                                    value={MEDIA_SOURCE_STREAM}
+                                    checked={mediaSource === MEDIA_SOURCE_STREAM}
                                     onChange={() => {
-                                        this.setState({ mediaSource: MEDIA_SOURCE_MJPEG });
+                                        this.setState({ mediaSource: MEDIA_SOURCE_STREAM });
                                     }}
                                 />
                                 {i18n._('Connect to an IP camera')}
@@ -154,14 +154,14 @@ class Settings extends PureComponent {
                             <input
                                 type="url"
                                 className="form-control"
-                                disabled={mediaSource !== MEDIA_SOURCE_MJPEG}
+                                disabled={mediaSource !== MEDIA_SOURCE_STREAM}
                                 placeholder="http://0.0.0.0:8080/?action=stream"
                                 defaultValue={url}
                                 onChange={this.handleChangeURL}
                             />
                             <Margin top={4}>
                                 <MutedText style={{ marginTop: 4 }}>
-                                    {i18n._('The URL must be for a Motion JPEG (mjpeg) HTTP or RTSP stream.')}
+                                    {i18n._('The URL must be for a Motion JPEG (mjpeg) HTTP RTSP or H264(MP4) stream.')}
                                 </MutedText>
                             </Margin>
                         </div>

--- a/src/app/widgets/Webcam/Webcam.jsx
+++ b/src/app/widgets/Webcam/Webcam.jsx
@@ -1,3 +1,4 @@
+/* eslint jsx-a11y/media-has-caption: 0 */
 import classNames from 'classnames';
 import Slider from 'rc-slider';
 import PropTypes from 'prop-types';
@@ -13,7 +14,7 @@ import Circle from './Circle';
 import styles from './index.styl';
 import {
     MEDIA_SOURCE_LOCAL,
-    MEDIA_SOURCE_MJPEG
+    MEDIA_SOURCE_STREAM
 } from './constants';
 
 // | Before                | After                   |
@@ -68,6 +69,8 @@ class Webcam extends PureComponent {
             muted
         } = state;
 
+        const isHtml5 = url.split('.').pop() === 'mp4';
+
         if (disabled) {
             return (
                 <div className={styles['webcam-off-container']}>
@@ -98,18 +101,31 @@ class Webcam extends PureComponent {
                         />
                     </div>
                 )}
-                {mediaSource === MEDIA_SOURCE_MJPEG && (
-                    <Image
-                        ref={node => {
-                            this.imageSource = node;
-                        }}
-                        src={mapMetaAddressToHostname(url)}
-                        style={{
-                            width: (100 * scale).toFixed(0) + '%',
-                            transform: transformStyle
-                        }}
-                        className={styles.center}
-                    />
+                {mediaSource === MEDIA_SOURCE_STREAM && (
+                    isHtml5
+                        ? (
+                            <video
+                                className={styles.center}
+                                style={{ transform: transformStyle }}
+                                width={(100 * scale).toFixed(0) + '%'}
+                                height="auto"
+                                muted={muted}
+                                src={mapMetaAddressToHostname(url)}
+                                autoPlay={true}
+                            />
+                        ) : (
+                            <Image
+                                ref={node => {
+                                    this.imageSource = node;
+                                }}
+                                src={mapMetaAddressToHostname(url)}
+                                style={{
+                                    width: (100 * scale).toFixed(0) + '%',
+                                    transform: transformStyle
+                                }}
+                                className={styles.center}
+                            />
+                        )
                 )}
                 {crosshair && (
                     <div>

--- a/src/app/widgets/Webcam/constants.js
+++ b/src/app/widgets/Webcam/constants.js
@@ -1,3 +1,3 @@
 // Media Source
 export const MEDIA_SOURCE_LOCAL = 'local';
-export const MEDIA_SOURCE_MJPEG = 'mjpeg';
+export const MEDIA_SOURCE_STREAM = 'stream';

--- a/src/app/widgets/Webcam/index.jsx
+++ b/src/app/widgets/Webcam/index.jsx
@@ -10,7 +10,7 @@ import Webcam from './Webcam';
 import Settings from './Settings';
 import styles from './index.styl';
 import {
-    MEDIA_SOURCE_LOCAL
+    MEDIA_SOURCE_LOCAL, MEDIA_SOURCE_STREAM
 } from './constants';
 
 class WebcamWidget extends PureComponent {
@@ -112,11 +112,16 @@ class WebcamWidget extends PureComponent {
     }
 
     getInitialState() {
+        // Upgrade existing config from MEDIA_SOURCE_MJPEG
+        let mediaSource = this.config.get('mediaSource', MEDIA_SOURCE_LOCAL);
+        if (mediaSource === 'mjpeg') {
+            mediaSource = MEDIA_SOURCE_STREAM;
+        }
         return {
             disabled: this.config.get('disabled', true),
             minimized: this.config.get('minimized', false),
             isFullscreen: false,
-            mediaSource: this.config.get('mediaSource', MEDIA_SOURCE_LOCAL),
+            mediaSource: mediaSource,
             deviceId: this.config.get('deviceId', ''),
             url: this.config.get('url', ''),
             scale: this.config.get('geometry.scale', 1.0),


### PR DESCRIPTION
A simple update to the webcam widget that allows the use of the HTML5 `<video/>` tag for suitable remote streams.

It means less faffing about and expensive conversions for those of us that have, say,  h264-capable webcams  attached to a pi. We may use for example [https://github.com/soyersoyer/fmp4streamer](https://github.com/soyersoyer/fmp4streamer)  

If your stream URL ends with ".mp4" it will simply switch out the `<Image/>` tag for `<video/>`  