### PR TITLE
feat: add functionality to set DTR/RTS line status on serial port open

### DIFF
--- a/src/app/i18n/cs/resource.json
+++ b/src/app/i18n/cs/resource.json
@@ -325,7 +325,6 @@
     "Refresh": "Obnovit",
     "Baud rate": "Rychlost",
     "Choose a baud rate": "Zvolte rychlost",
-    "Enable hardware flow control": "",
     "Connect automatically": "Automaticky připojit",
     "Open": "Otevřít",
     "Error opening serial port '{{- port}}'": "",
@@ -533,5 +532,10 @@
     "Show Cutting Tool": "",
     "Ready to start": "",
     "Connect to an IP camera": "",
-    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": ""
+    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": "",
+    "Set DTR line status upon opening": "Nastavit stav řádky DTR při otevírání",
+    "SET": "NASTAVIT",
+    "CLR": "VYMAZAT",
+    "Set RTS line status upon opening": "Nastavit stav řádky RTS při otevírání",
+    "Use RTS/CTS flow control": "Použijte řízení toku RTS/CTS"
 }

--- a/src/app/i18n/de/resource.json
+++ b/src/app/i18n/de/resource.json
@@ -325,7 +325,6 @@
     "Refresh": "Aktualisieren",
     "Baud rate": "Baudrate",
     "Choose a baud rate": "Baudrate wählen",
-    "Enable hardware flow control": "",
     "Connect automatically": "Automatisch verbinden",
     "Open": "Öffnen",
     "Error opening serial port '{{- port}}'": "Fehler beim Öffnen des seriellen Ports '{{- port}}'",
@@ -533,5 +532,10 @@
     "Show Cutting Tool": "",
     "Ready to start": "",
     "Connect to an IP camera": "",
-    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": ""
+    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": "",
+    "Set DTR line status upon opening": "Setze den DTR-Leitungsstatus beim Öffnen",
+    "SET": "SETZEN",
+    "CLR": "LÖSCHEN",
+    "Set RTS line status upon opening": "Setze den RTS-Leitungsstatus beim Öffnen",
+    "Use RTS/CTS flow control": "Verwende RTS/CTS-Flusskontrolle"
 }

--- a/src/app/i18n/en/resource.json
+++ b/src/app/i18n/en/resource.json
@@ -325,7 +325,6 @@
     "Refresh": "Refresh",
     "Baud rate": "Baud rate",
     "Choose a baud rate": "Choose a baud rate",
-    "Enable hardware flow control": "Enable hardware flow control",
     "Connect automatically": "Connect automatically",
     "Open": "Open",
     "Error opening serial port '{{- port}}'": "Error opening serial port '{{- port}}'",
@@ -533,5 +532,10 @@
     "Show Cutting Tool": "Show Cutting Tool",
     "Ready to start": "Ready to start",
     "Connect to an IP camera": "Connect to an IP camera",
-    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4)."
+    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).",
+    "Set DTR line status upon opening": "Set DTR line status upon opening",
+    "SET": "SET",
+    "CLR": "CLR",
+    "Set RTS line status upon opening": "Set RTS line status upon opening",
+    "Use RTS/CTS flow control": "Use RTS/CTS flow control"
 }

--- a/src/app/i18n/es/resource.json
+++ b/src/app/i18n/es/resource.json
@@ -325,7 +325,6 @@
     "Refresh": "Actualizar",
     "Baud rate": "Baud rate",
     "Choose a baud rate": "Elija",
-    "Enable hardware flow control": "",
     "Connect automatically": "Conectar automaticamente",
     "Open": "Abrir",
     "Error opening serial port '{{- port}}'": "Error al abrir el puerto serie '{{- port}}'",
@@ -533,5 +532,10 @@
     "Show Cutting Tool": "",
     "Ready to start": "",
     "Connect to an IP camera": "",
-    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": ""
+    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": "",
+    "Set DTR line status upon opening": "Establecer el estado de la línea DTR al abrir",
+    "SET": "ESTABLECER",
+    "CLR": "BORRAR",
+    "Set RTS line status upon opening": "Establecer el estado de la línea RTS al abrir",
+    "Use RTS/CTS flow control": "Utilice control de flujo RTS/CTS"
 }

--- a/src/app/i18n/fr/resource.json
+++ b/src/app/i18n/fr/resource.json
@@ -325,7 +325,6 @@
     "Refresh": "Actualiser",
     "Baud rate": "Vitesse de transmission",
     "Choose a baud rate": "Selectionner le 'Baudrate'",
-    "Enable hardware flow control": "",
     "Connect automatically": "Connecter automatiquement",
     "Open": "Ouvrir",
     "Error opening serial port '{{- port}}'": "",
@@ -533,5 +532,10 @@
     "Show Cutting Tool": "",
     "Ready to start": "",
     "Connect to an IP camera": "",
-    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": ""
+    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": "",
+    "Set DTR line status upon opening": "Définir l'état de la ligne DTR à l'ouverture",
+    "SET": "ÉTABLIR",
+    "CLR": "CLR",
+    "Set RTS line status upon opening": "Définir l'état de la ligne RTS à l'ouverture",
+    "Use RTS/CTS flow control": "Utilisez le contrôle de flux RTS/CTS"
 }

--- a/src/app/i18n/hu/resource.json
+++ b/src/app/i18n/hu/resource.json
@@ -325,7 +325,6 @@
     "Refresh": "Frissítés",
     "Baud rate": "Átviteli sebesség",
     "Choose a baud rate": "Átviteli sebesség választás",
-    "Enable hardware flow control": "",
     "Connect automatically": "Automatikus csatlakozás",
     "Open": "Csatlakozás",
     "Error opening serial port '{{- port}}'": "",
@@ -533,5 +532,10 @@
     "Show Cutting Tool": "",
     "Ready to start": "",
     "Connect to an IP camera": "",
-    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": ""
+    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": "",
+    "Set DTR line status upon opening": "DTR vonal állapotának beállítása az nyitáskor",
+    "SET": "BEÁLLÍT",
+    "CLR": "TÖRLÉS",
+    "Set RTS line status upon opening": "RTS vonal állapotának beállítása az nyitáskor",
+    "Use RTS/CTS flow control": "Használjon RTS/CTS áramvezérlést"
 }

--- a/src/app/i18n/it/resource.json
+++ b/src/app/i18n/it/resource.json
@@ -325,7 +325,6 @@
     "Refresh": "Aggiorna",
     "Baud rate": "",
     "Choose a baud rate": "",
-    "Enable hardware flow control": "",
     "Connect automatically": "Connetti automaticamente",
     "Open": "Apri",
     "Error opening serial port '{{- port}}'": "",
@@ -533,5 +532,10 @@
     "Show Cutting Tool": "",
     "Ready to start": "",
     "Connect to an IP camera": "",
-    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": ""
+    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": "",
+    "Set DTR line status upon opening": "Imposta lo stato della linea DTR all'apertura",
+    "SET": "IMPOSTA",
+    "CLR": "CANCELLA",
+    "Set RTS line status upon opening": "Imposta lo stato della linea RTS all'apertura",
+    "Use RTS/CTS flow control": "Utilizzare il controllo di flusso RTS/CTS"
 }

--- a/src/app/i18n/ja/resource.json
+++ b/src/app/i18n/ja/resource.json
@@ -325,7 +325,6 @@
     "Refresh": "表示更新",
     "Baud rate": "ボーレート",
     "Choose a baud rate": "ボーレートを選択",
-    "Enable hardware flow control": "ハードウェアフローコントロールを有効",
     "Connect automatically": "自動的に接続",
     "Open": "開く",
     "Error opening serial port '{{- port}}'": "シリアルポート '{{- port}}' を開くのに失敗しました",
@@ -533,5 +532,10 @@
     "Show Cutting Tool": "工具を表示する",
     "Ready to start": "スタートの準備ができました",
     "Connect to an IP camera": "IPカメラと接続",
-    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": ""
+    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": "",
+    "Set DTR line status upon opening": "開くときにDTRラインの状態を設定する",
+    "SET": "設定",
+    "CLR": "クリア",
+    "Set RTS line status upon opening": "開くときにRTSラインの状態を設定する",
+    "Use RTS/CTS flow control": "RTS/CTSフロー制御を使用する"
 }

--- a/src/app/i18n/nb/resource.json
+++ b/src/app/i18n/nb/resource.json
@@ -325,7 +325,6 @@
     "Refresh": "Oppfrisk",
     "Baud rate": "Baud-hastighet",
     "Choose a baud rate": "Velg baud-hastighet",
-    "Enable hardware flow control": "Enable hardware flow control",
     "Connect automatically": "Koble til automatisk",
     "Open": "Åpne",
     "Error opening serial port '{{- port}}'": "Feil i åpning av seriellport '{{- port}}'",
@@ -533,5 +532,10 @@
     "Show Cutting Tool": "Vis skjæreverktøy",
     "Ready to start": "Klar til å starte",
     "Connect to an IP camera": "Koble til et IP-kamera",
-    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": ""
+    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": "",
+    "Set DTR line status upon opening": "Sett DTR-linjestatus ved åpning",
+    "SET": "SETT",
+    "CLR": "SLETT",
+    "Set RTS line status upon opening": "Sett RTS-linjestatus ved åpning",
+    "Use RTS/CTS flow control": "Bruk RTS/CTS strømstyring"
 }

--- a/src/app/i18n/nl/resource.json
+++ b/src/app/i18n/nl/resource.json
@@ -325,7 +325,6 @@
     "Refresh": "Ververs",
     "Baud rate": "Verbindingssnelheid",
     "Choose a baud rate": "Kies een verbindingssnelheid",
-    "Enable hardware flow control": "Schakel hardware flow control in",
     "Connect automatically": "Verbind automatisch",
     "Open": "Open",
     "Error opening serial port '{{- port}}'": "Fout bij openen seriële poort",
@@ -533,5 +532,10 @@
     "Show Cutting Tool": "Laat gereedschap zien",
     "Ready to start": "Klaar om te starten",
     "Connect to an IP camera": "Verbind met een IP camera",
-    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": ""
+    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": "",
+    "Set DTR line status upon opening": "Stel DTR-lijnstatus in bij opening",
+    "SET": "INSTELLEN",
+    "CLR": "WISSEN",
+    "Set RTS line status upon opening": "Stel RTS-lijnstatus in bij opening",
+    "Use RTS/CTS flow control": "Gebruik RTS/CTS-stroomregeling"
 }

--- a/src/app/i18n/pt-br/resource.json
+++ b/src/app/i18n/pt-br/resource.json
@@ -325,7 +325,6 @@
     "Refresh": "Atualizar",
     "Baud rate": "Taxa de transmissão",
     "Choose a baud rate": "Escolha uma taxa de transmissão (baud rate)",
-    "Enable hardware flow control": "Ativar controle de fluxo de hardware",
     "Connect automatically": "Conectar automaticamente",
     "Open": "Abrir",
     "Error opening serial port '{{- port}}'": "Erro abrindo porta serial '{{- port}}'",
@@ -533,5 +532,10 @@
     "Show Cutting Tool": "",
     "Ready to start": "",
     "Connect to an IP camera": "",
-    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": ""
+    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": "",
+    "Set DTR line status upon opening": "Definir status da linha DTR na abertura",
+    "SET": "DEFINIR",
+    "CLR": "LIMPAR",
+    "Set RTS line status upon opening": "Definir status da linha RTS na abertura",
+    "Use RTS/CTS flow control": "Use o controle de fluxo RTS/CTS"
 }

--- a/src/app/i18n/pt-pt/resource.json
+++ b/src/app/i18n/pt-pt/resource.json
@@ -325,7 +325,6 @@
     "Refresh": "Atualizar",
     "Baud rate": "Taxa de transmissão",
     "Choose a baud rate": "Escolha uma taxa de transmissão (baud rate)",
-    "Enable hardware flow control": "Ativar controle de fluxo de hardware",
     "Connect automatically": "Conectar automaticamente",
     "Open": "Abrir",
     "Error opening serial port '{{- port}}'": "Erro ao abrir porta série '{{- port}}'",
@@ -533,5 +532,10 @@
     "Show Cutting Tool": "Mostrar Ferramenta",
     "Ready to start": "",
     "Connect to an IP camera": "Conectar a câmera IP",
-    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": ""
+    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": "",
+    "Set DTR line status upon opening": "Definir estado da linha DTR na abertura",
+    "SET": "DEFINIR",
+    "CLR": "LIMPAR",
+    "Set RTS line status upon opening": "Definir estado da linha RTS na abertura",
+    "Use RTS/CTS flow control": "Use o controlo de fluxo RTS/CTS"
 }

--- a/src/app/i18n/ru/resource.json
+++ b/src/app/i18n/ru/resource.json
@@ -325,7 +325,6 @@
     "Refresh": "Обновить",
     "Baud rate": "Скорость передачи (baud rate)",
     "Choose a baud rate": "Выберите скорость (baud rate)",
-    "Enable hardware flow control": "",
     "Connect automatically": "Подключать автоматически",
     "Open": "Открыть",
     "Error opening serial port '{{- port}}'": "",
@@ -533,5 +532,10 @@
     "Show Cutting Tool": "",
     "Ready to start": "",
     "Connect to an IP camera": "",
-    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": ""
+    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": "",
+    "Set DTR line status upon opening": "Установить статус линии DTR при открытии",
+    "SET": "УСТАНОВИТЬ",
+    "CLR": "ОЧИСТИТЬ",
+    "Set RTS line status upon opening": "Установить статус линии RTS при открытии",
+    "Use RTS/CTS flow control": "Используйте контроль потока RTS/CTS"
 }

--- a/src/app/i18n/tr/resource.json
+++ b/src/app/i18n/tr/resource.json
@@ -325,7 +325,6 @@
     "Refresh": "Yenile",
     "Baud rate": "Band hızı",
     "Choose a baud rate": "Bir band hızı seçin",
-    "Enable hardware flow control": "Donanım akış denetimini etkinleştir",
     "Connect automatically": "Otomatik bağlan",
     "Open": "Aç",
     "Error opening serial port '{{- port}}'": "Seri bağlantı noktası açılırken hata oluştu '{{- port}}'",
@@ -533,5 +532,10 @@
     "Show Cutting Tool": "",
     "Ready to start": "",
     "Connect to an IP camera": "",
-    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": ""
+    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": "",
+    "Set DTR line status upon opening": "Açılışta DTR hat durumunu ayarla",
+    "SET": "AYARLA",
+    "CLR": "TEMİZLE",
+    "Set RTS line status upon opening": "Açılışta RTS hat durumunu ayarla",
+    "Use RTS/CTS flow control": "RTS/CTS akış kontrolü kullanın"
 }

--- a/src/app/i18n/zh-cn/resource.json
+++ b/src/app/i18n/zh-cn/resource.json
@@ -325,7 +325,6 @@
     "Refresh": "刷新",
     "Baud rate": "波特率",
     "Choose a baud rate": "选择波特率",
-    "Enable hardware flow control": "开启硬件流控制",
     "Connect automatically": "自动连接",
     "Open": "打开",
     "Error opening serial port '{{- port}}'": "打开端口'{{- port}}'失败",
@@ -533,5 +532,10 @@
     "Show Cutting Tool": "",
     "Ready to start": "",
     "Connect to an IP camera": "",
-    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": ""
+    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": "",
+    "Set DTR line status upon opening": "打开时设置DTR线路状态",
+    "SET": "设置",
+    "CLR": "清除",
+    "Set RTS line status upon opening": "打开时设置RTS线路状态",
+    "Use RTS/CTS flow control": "使用RTS/CTS流控制"
 }

--- a/src/app/i18n/zh-tw/resource.json
+++ b/src/app/i18n/zh-tw/resource.json
@@ -325,7 +325,6 @@
     "Refresh": "重新整理",
     "Baud rate": "鮑率",
     "Choose a baud rate": "選擇鮑率",
-    "Enable hardware flow control": "",
     "Connect automatically": "自動連線",
     "Open": "開啟",
     "Error opening serial port '{{- port}}'": "",
@@ -533,5 +532,10 @@
     "Show Cutting Tool": "",
     "Ready to start": "",
     "Connect to an IP camera": "",
-    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": ""
+    "The URL should point to a stream in one of the following formats: Motion JPEG (mjpeg), RTSP, or H264 (MP4).": "",
+    "Set DTR line status upon opening": "開啟時設置DTR線路狀態",
+    "SET": "設置",
+    "CLR": "清除",
+    "Set RTS line status upon opening": "開啟時設置RTS線路狀態",
+    "Use RTS/CTS flow control": "使用RTS/CTS流量控制"
 }

--- a/src/app/store/defaultState.js
+++ b/src/app/store/defaultState.js
@@ -65,9 +65,15 @@ const defaultState = {
       connection: {
         type: 'serial',
         serial: {
-          // Hardware flow control (RTS/CTS)
-          rtscts: false
-        }
+          // RTS/CTS flow control
+          rtscts: false,
+          pin: {
+            // Set DTR line status (default to null)
+            dtr: null,
+            // Set RTS line status (default to null)
+            rts: null,
+          },
+        },
       },
       autoReconnect: true
     },

--- a/src/app/widgets/Connection/Connection.jsx
+++ b/src/app/widgets/Connection/Connection.jsx
@@ -107,7 +107,12 @@ class Connection extends PureComponent {
         connection,
         alertMessage
       } = state;
-      const enableHardwareFlowControl = get(connection, 'serial.rtscts', false);
+      const pin = get(connection, 'serial.pin');
+      // Set or clear the DTR line immediately upon opening. No action will be taken if the state is not a boolean type.
+      const enableDTRPin = (typeof pin?.dtr === 'boolean');
+      // Set or clear the RTS line immediately upon opening. No action will be taken if the state is not a boolean type.
+      const enableRTSPin = (typeof pin?.rts === 'boolean');
+      const enableRTSCTSFlowControl = get(connection, 'serial.rtscts', false);
       const canSelectControllers = (controller.loadedControllers.length > 1);
       const hasGrblController = includes(controller.loadedControllers, GRBL);
       const hasMarlinController = includes(controller.loadedControllers, MARLIN);
@@ -120,7 +125,6 @@ class Connection extends PureComponent {
       const canChangeController = notLoading && notConnected;
       const canChangePort = notLoading && notConnected;
       const canChangeBaudrate = notLoading && notConnected && (!(this.isPortInUse(port)));
-      const canToggleHardwareFlowControl = notConnected;
       const canOpenPort = port && baudrate && notConnecting && notConnected;
       const canClosePort = connected;
 
@@ -272,17 +276,107 @@ class Connection extends PureComponent {
           </div>
           <div
             className={cx('checkbox', {
-              'disabled': !canToggleHardwareFlowControl
+              'disabled': connected,
             })}
           >
             <label>
               <input
                 type="checkbox"
-                defaultChecked={enableHardwareFlowControl}
-                onChange={actions.toggleHardwareFlowControl}
-                disabled={!canToggleHardwareFlowControl}
+                defaultChecked={enableDTRPin}
+                onChange={actions.toggleDTRPin}
+                disabled={connected}
               />
-              {i18n._('Enable hardware flow control')}
+              {i18n._('Set DTR line status upon opening')}
+            </label>
+          </div>
+          {enableDTRPin && (
+            <div style={{ marginLeft: 20 }}>
+              <div className="input-group input-group-xs">
+                <div className="input-group-btn">
+                  <button
+                    type="button"
+                    className={cx(
+                      'btn',
+                      'btn-default',
+                      { 'btn-select': !!pin.dtr }
+                    )}
+                    onClick={actions.setDTR}
+                  >
+                    {i18n._('SET')}
+                  </button>
+                  <button
+                    type="button"
+                    className={cx(
+                      'btn',
+                      'btn-default',
+                      { 'btn-select': !pin.dtr }
+                    )}
+                    onClick={actions.clearDTR}
+                  >
+                    {i18n._('CLR')}
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+          <div
+            className={cx('checkbox', {
+              'disabled': connected,
+            })}
+          >
+            <label>
+              <input
+                type="checkbox"
+                defaultChecked={enableRTSPin}
+                onChange={actions.toggleRTSPin}
+                disabled={connected}
+              />
+              {i18n._('Set RTS line status upon opening')}
+            </label>
+          </div>
+          {enableRTSPin && (
+            <div style={{ marginLeft: 20 }}>
+              <div className="input-group input-group-xs">
+                <div className="input-group-btn">
+                  <button
+                    type="button"
+                    className={cx(
+                      'btn',
+                      'btn-default',
+                      { 'btn-select': !!pin.rts }
+                    )}
+                    onClick={actions.setRTS}
+                  >
+                    {i18n._('SET')}
+                  </button>
+                  <button
+                    type="button"
+                    className={cx(
+                      'btn',
+                      'btn-default',
+                      { 'btn-select': !pin.rts }
+                    )}
+                    onClick={actions.clearRTS}
+                  >
+                    {i18n._('CLR')}
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+          <div
+            className={cx('checkbox', {
+              'disabled': connected,
+            })}
+          >
+            <label>
+              <input
+                type="checkbox"
+                defaultChecked={enableRTSCTSFlowControl}
+                onChange={actions.toggleRTSCTSFlowControl}
+                disabled={connected}
+              />
+              {i18n._('Use RTS/CTS flow control')}
             </label>
           </div>
           <div className="checkbox">

--- a/src/app/widgets/Connection/index.jsx
+++ b/src/app/widgets/Connection/index.jsx
@@ -79,7 +79,7 @@ class ConnectionWidget extends PureComponent {
           autoReconnect: checked
         }));
       },
-      toggleHardwareFlowControl: (event) => {
+      toggleRTSCTSFlowControl: (event) => {
         const checked = event.target.checked;
         this.setState(state => ({
           connection: {
@@ -89,6 +89,92 @@ class ConnectionWidget extends PureComponent {
               rtscts: checked
             }
           }
+        }));
+      },
+      toggleDTRPin: (event) => {
+        const checked = event.target.checked;
+        this.setState(state => ({
+          connection: {
+            ...state.connection,
+            serial: {
+              ...state.connection.serial,
+              pin: {
+                ...state.connection.serial.pin,
+                dtr: checked ? true : null, // Set DTR pin to `true` when checked, and to `null` when unchecked
+              },
+            }
+          }
+        }));
+      },
+      setDTR: () => {
+        this.setState(state => ({
+          connection: {
+            ...state.connection,
+            serial: {
+              ...state.connection.serial,
+              pin: {
+                ...state.connection.serial.pin,
+                dtr: true,
+              },
+            },
+          },
+        }));
+      },
+      clearDTR: () => {
+        this.setState(state => ({
+          connection: {
+            ...state.connection,
+            serial: {
+              ...state.connection.serial,
+              pin: {
+                ...state.connection.serial.pin,
+                dtr: false,
+              },
+            },
+          },
+        }));
+      },
+      toggleRTSPin: (event) => {
+        const checked = event.target.checked;
+        this.setState(state => ({
+          connection: {
+            ...state.connection,
+            serial: {
+              ...state.connection.serial,
+              pin: {
+                ...state.connection.serial.pin,
+                rts: checked ? true : null, // Set RTS pin to `true` when checked, and to `null` when unchecked
+              },
+            }
+          }
+        }));
+      },
+      setRTS: () => {
+        this.setState(state => ({
+          connection: {
+            ...state.connection,
+            serial: {
+              ...state.connection.serial,
+              pin: {
+                ...state.connection.serial.pin,
+                rts: true,
+              },
+            },
+          },
+        }));
+      },
+      clearRTS: () => {
+        this.setState(state => ({
+          connection: {
+            ...state.connection,
+            serial: {
+              ...state.connection.serial,
+              pin: {
+                ...state.connection.serial.pin,
+                rts: false,
+              },
+            },
+          },
         }));
       },
       handleRefreshPorts: (event) => {
@@ -229,6 +315,8 @@ class ConnectionWidget extends PureComponent {
       }
       if (connection) {
         this.config.set('connection.serial.rtscts', get(connection, 'serial.rtscts', false));
+        this.config.set('connection.serial.pin.dtr', get(connection, 'serial.pin.dtr', null));
+        this.config.set('connection.serial.pin.rts', get(connection, 'serial.pin.rts', null));
       }
       this.config.set('autoReconnect', autoReconnect);
     }
@@ -264,7 +352,11 @@ class ConnectionWidget extends PureComponent {
         baudrate: this.config.get('baudrate'),
         connection: {
           serial: {
-            rtscts: this.config.get('connection.serial.rtscts')
+            rtscts: this.config.get('connection.serial.rtscts'),
+            pin: {
+              dtr: this.config.get('connection.serial.pin.dtr'),
+              rts: this.config.get('connection.serial.pin.rts'),
+            },
           }
         },
         autoReconnect: this.config.get('autoReconnect'),
@@ -325,7 +417,11 @@ class ConnectionWidget extends PureComponent {
       controller.openPort(port, {
         controllerType: this.state.controllerType,
         baudrate: baudrate,
-        rtscts: this.state.connection.serial.rtscts
+        rtscts: this.state.connection.serial.rtscts,
+        pin: {
+          dtr: this.state.connection.serial.pin.dtr,
+          rts: this.state.connection.serial.pin.rts,
+        },
       }, (err) => {
         if (err) {
           this.setState(state => ({

--- a/src/server/controllers/Grbl/GrblController.js
+++ b/src/server/controllers/Grbl/GrblController.js
@@ -136,12 +136,13 @@ class GrblController {
       }
       this.engine = engine;
 
-      const { port, baudrate, rtscts } = { ...options };
+      const { port, baudrate, rtscts, pin } = { ...options };
       this.options = {
         ...this.options,
         port: port,
         baudrate: baudrate,
-        rtscts: rtscts
+        rtscts: rtscts,
+        pin,
       };
 
       // Connection
@@ -193,9 +194,9 @@ class GrblController {
         dataFilter: (line, context) => {
           const originalLine = line;
           /**
-                 * line = 'G0X10 ; comment text'
-                 * parts = ['G0X10 ', ' comment text', '']
-                 */
+           * line = 'G0X10 ; comment text'
+           * parts = ['G0X10 ', ' comment text', '']
+           */
           const parts = originalLine.split(/;(.*)/s); // `s` is the modifier for single-line mode
           line = ensureString(parts[0]).trim();
           context = this.populateContext(context);
@@ -890,7 +891,7 @@ class GrblController {
     }
 
     open(callback = noop) {
-      const { port, baudrate } = this.options;
+      const { port, baudrate, pin } = this.options;
 
       // Assertion check
       if (this.isOpen()) {
@@ -902,12 +903,37 @@ class GrblController {
       this.connection.on('close', this.connectionEventListener.close);
       this.connection.on('error', this.connectionEventListener.error);
 
-      this.connection.open((err) => {
+      this.connection.open(async (err) => {
         if (err) {
           log.error(`Error opening serial port "${port}":`, err);
           this.emit('serialport:error', { err: err, port: port });
           callback(err); // notify error
           return;
+        }
+
+        let setOptions = null;
+        try {
+          // Set DTR and RTS control flags if they exist
+          if (typeof pin?.dtr === 'boolean') {
+            setOptions = {
+              ...setOptions,
+              dtr: pin?.dtr,
+            };
+          }
+          if (typeof pin?.rts === 'boolean') {
+            setOptions = {
+              ...setOptions,
+              rts: pin?.rts,
+            };
+          }
+
+          if (setOptions) {
+            await delay(100);
+            await this.connection.port.set(setOptions);
+            await delay(100);
+          }
+        } catch (err) {
+          log.error('Failed to set control flags:', { err, port });
         }
 
         this.emit('serialport:open', {

--- a/src/server/controllers/Marlin/MarlinController.js
+++ b/src/server/controllers/Marlin/MarlinController.js
@@ -13,6 +13,7 @@ import Workflow, {
   WORKFLOW_STATE_PAUSED,
   WORKFLOW_STATE_RUNNING
 } from '../../lib/Workflow';
+import delay from '../../lib/delay';
 import ensurePositiveNumber from '../../lib/ensure-positive-number';
 import evaluateAssignmentExpression from '../../lib/evaluate-assignment-expression';
 import logger from '../../lib/logger';
@@ -219,12 +220,13 @@ class MarlinController {
       }
       this.engine = engine;
 
-      const { port, baudrate, rtscts } = { ...options };
+      const { port, baudrate, rtscts, pin } = { ...options };
       this.options = {
         ...this.options,
         port: port,
         baudrate: baudrate,
-        rtscts: rtscts
+        rtscts: rtscts,
+        pin,
       };
 
       // Connection
@@ -350,9 +352,9 @@ class MarlinController {
         dataFilter: (line, context) => {
           const originalLine = line;
           /**
-                 * line = 'G0X10 ; comment text'
-                 * parts = ['G0X10 ', ' comment text', '']
-                 */
+           * line = 'G0X10 ; comment text'
+           * parts = ['G0X10 ', ' comment text', '']
+           */
           const parts = originalLine.split(/;(.*)/s); // `s` is the modifier for single-line mode
           line = ensureString(parts[0]).trim();
           context = this.populateContext(context);
@@ -904,7 +906,7 @@ class MarlinController {
     }
 
     open(callback = noop) {
-      const { port, baudrate } = this.options;
+      const { port, baudrate, pin } = this.options;
 
       // Assertion check
       if (this.isOpen()) {
@@ -916,12 +918,37 @@ class MarlinController {
       this.connection.on('close', this.connectionEventListener.close);
       this.connection.on('error', this.connectionEventListener.error);
 
-      this.connection.open((err) => {
+      this.connection.open(async (err) => {
         if (err) {
           log.error(`Error opening serial port "${port}":`, err);
           this.emit('serialport:error', { err: err, port: port });
           callback(err); // notify error
           return;
+        }
+
+        let setOptions = null;
+        try {
+          // Set DTR and RTS control flags if they exist
+          if (typeof pin?.dtr === 'boolean') {
+            setOptions = {
+              ...setOptions,
+              dtr: pin?.dtr,
+            };
+          }
+          if (typeof pin?.rts === 'boolean') {
+            setOptions = {
+              ...setOptions,
+              rts: pin?.rts,
+            };
+          }
+
+          if (setOptions) {
+            await delay(100);
+            await this.connection.port.set(setOptions);
+            await delay(100);
+          }
+        } catch (err) {
+          log.error('Failed to set control flags:', { err, port });
         }
 
         this.emit('serialport:open', {

--- a/src/server/lib/SerialConnection.js
+++ b/src/server/lib/SerialConnection.js
@@ -28,12 +28,12 @@ const toIdent = (options) => {
 class SerialConnection extends EventEmitter {
     type = 'serial';
 
+    // Readline parser
     parser = null;
 
-    // Readline parser
+    // SerialPort
     port = null;
 
-    // SerialPort
     writeFilter = (data) => data;
 
     eventListener = {

--- a/src/server/services/cncengine/CNCEngine.js
+++ b/src/server/services/cncengine/CNCEngine.js
@@ -232,7 +232,7 @@ class CNCEngine {
 
           let controller = store.get(`controllers["${port}"]`);
           if (!controller) {
-            let { controllerType = GRBL, baudrate, rtscts } = { ...options };
+            let { controllerType = GRBL, baudrate, rtscts, pin } = { ...options };
 
             if (controllerType === 'TinyG2') {
               // TinyG2 is deprecated and will be removed in a future release
@@ -251,7 +251,8 @@ class CNCEngine {
             controller = new Controller(engine, {
               port: port,
               baudrate: baudrate,
-              rtscts: !!rtscts
+              rtscts: !!rtscts,
+              pin,
             });
           }
 


### PR DESCRIPTION
## Overview

This PR adds two options that allows users to set or clear DTR and RTS line status when the serial connection is opened. The process is intended for the Arduino Due board, but may also work for certain other boards.

![image](https://user-images.githubusercontent.com/447801/228857642-b929b9f5-4c21-49ef-8d67-9d4f4e60e00a.png)

https://user-images.githubusercontent.com/447801/228857357-d00a2b48-89ff-4978-8a62-380a51f814b7.mp4

## References

https://playground.arduino.cc/Main/DisablingAutoResetOnSerialConnection/
https://arduino.stackexchange.com/questions/38012/major-difference-between-dtr-signal-and-rts-signal
https://www.geeksforgeeks.org/difference-between-rts-cts-and-dtr-dsr-flow-control/
https://github.com/serialport/node-serialport/blob/6f453b60ac22909334dd128832d7b5eceecbbca6/examples/reset.js
https://forum.arduino.cc/t/disable-auto-reset-by-serial-connection/28248/4
https://forum.arduino.cc/t/software-disable-auto-reset-on-connection-with-the-arduino-due/369222
https://forum.arduino.cc/t/how-to-make-a-dtr-reset/385699
https://forum.arduino.cc/t/does-arduino-reset-when-first-connected-to-usb/544278/9
https://github.com/Fazecast/jSerialComm/blob/master/src/main/c/Windows/SerialPort_Windows.c#L693-L701