### PR TITLE
fix: resolve conflicting shortcut key assignments in `Combokeys`

### DIFF
--- a/src/app/lib/combokeys.js
+++ b/src/app/lib/combokeys.js
@@ -110,7 +110,7 @@ const commandKeys = [
     preventDefault: true
   },
   { // Jog Backward (Alias)
-    keys: ['ctrl', 'alt', 'command', 'b'].join('+'),
+    keys: ['ctrl', 'alt', 'command', 'k'].join('+'),
     cmd: 'JOG',
     payload: {
       axis: null,


### PR DESCRIPTION
The wiki page has been updated as followed:
https://github.com/cncjs/cncjs/wiki/User-Guide#keyboard-shortcuts

* <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>command</kbd> + <kbd>]</kbd> or <kbd>f</kbd> - Jog Forward<br>
* <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>command</kbd> + <kbd>[</kbd> or <kbd>k</kbd> - Jog Backward<br>


### **PR Type**
bug_fix


___

### **Description**
- Resolved a conflict in shortcut key assignments within the `Combokeys` library.
- Updated the key combination for the Jog Backward command to prevent conflicts.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>combokeys.js</strong><dd><code>Resolve conflicting shortcut key assignments in Combokeys</code></dd></summary>
<hr>

src/app/lib/combokeys.js

<li>Changed the shortcut key assignment for the Jog Backward command.<br> <li> Updated the key combination from 'ctrl+alt+command+b' to <br>'ctrl+alt+command+k'.<br>


</details>


  </td>
  <td><a href="https://github.com/cncjs/cncjs/pull/875/files#diff-e08c8240a57e49328cf89738e656a84cccd1f9e5c98ff95d884837f60e6c6a0b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information