### PR TITLE
feat(`g2`, `tinyg`): add `jogCancel` command to cancel jogging using feedhold and queue flush

### DIFF
--- a/src/server/controllers/TinyG/TinyGController.js
+++ b/src/server/controllers/TinyG/TinyGController.js
@@ -1268,6 +1268,13 @@ class TinyGController {
           this.feeder.reset();
           this.write('\x18'); // reset board (^x)
         },
+        'jogCancel': () => {
+          // https://github.com/synthetos/g2/wiki/Feedhold,-Resume,-and-Other-Simple-Commands#jogging-using-feedhold-and-queue-flush
+          // Send a ! to stop movement immediately.
+          // Send a % to flush remaining moves from planner buffer.
+          this.writeln('!'); // feedhold
+          this.writeln('%'); // queue flush
+        },
         // Feed Overrides
         // @param {number} value A percentage value between 5 and 200. A value of zero will reset to 100%.
         'feedOverride': () => {


### PR DESCRIPTION
https://github.com/synthetos/g2/wiki/Feedhold,-Resume,-and-Other-Simple-Commands#jogging-using-feedhold-and-queue-flush

* Send a `!` to stop movement immediately
* Send a `%` to flush remaining moves from planner buffer

### **PR Type**
enhancement


___

### **Description**
- Introduced a new `jogCancel` command in the TinyGController to enhance jogging control.
- The `jogCancel` command stops movement immediately using feedhold and flushes the queue to clear remaining moves.
- This implementation follows the guidelines from the g2 wiki on jogging using feedhold and queue flush.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TinyGController.js</strong><dd><code>Add `jogCancel` command to TinyGController</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/controllers/TinyG/TinyGController.js

<li>Added a new <code>jogCancel</code> command to the TinyGController.<br> <li> Implemented immediate stop of movement using feedhold.<br> <li> Implemented queue flush to clear remaining moves from the planner <br>buffer.<br>


</details>


  </td>
  <td><a href="https://github.com/cncjs/cncjs/pull/876/files#diff-b8653e7ac2e09f034d725fb7bd626fb10308ee8a63fb5d6708f50313a72dce1c">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information