### PR TITLE
feat(Grbl): support UART communication without resetting the connection upon opening

### DIFF
--- a/src/server/controllers/Grbl/GrblController.js
+++ b/src/server/controllers/Grbl/GrblController.js
@@ -409,6 +409,23 @@ class GrblController {
       this.runner.on('raw', noop);
 
       this.runner.on('status', (res) => {
+        /**
+         * Handle the scenario where a startup message is not received during UART communication.
+         * A status query (?) will be issued in the `queryActivity` function.
+         */
+        if (!this.ready) {
+          this.ready = true;
+
+          // Reset the state
+          this.clearActionValues();
+        }
+        if (!this.initialized) {
+          this.initialized = true;
+
+          // Initialize controller
+          this.initController();
+        }
+
         this.actionMask.queryStatusReport = false;
 
         if (this.actionMask.replyStatusReport) {
@@ -574,12 +591,14 @@ class GrblController {
       this.runner.on('startup', (res) => {
         this.emit('serialport:read', res.raw);
 
-        // The startup message always prints upon startup, after a reset, or at program end.
-        // Setting the initial state when Grbl has completed re-initializing all systems.
-        this.clearActionValues();
+        if (!this.ready) {
+          // The startup message always prints upon startup, after a reset, or at program end.
+          // Setting the initial state when Grbl has completed re-initializing all systems.
+          this.clearActionValues();
 
-        // Set ready flag to true when a startup message has arrived
-        this.ready = true;
+          // Set ready flag to true when a startup message has arrived
+          this.ready = true;
+        }
 
         if (!this.initialized) {
           this.initialized = true;
@@ -592,6 +611,13 @@ class GrblController {
       this.runner.on('others', (res) => {
         this.emit('serialport:read', res.raw);
       });
+
+      // Restrict the function to execute once within the specified time interval, occurring only on the trailing edge of the timeout.
+      const queryActivity = _.throttle(() => {
+        if (this.isOpen()) {
+          this.connection.write('?');
+        }
+      }, 2000, { trailing: true });
 
       const queryStatusReport = () => {
         // Check the ready flag
@@ -701,6 +727,7 @@ class GrblController {
 
         // Check the ready flag
         if (!(this.ready)) {
+          queryActivity();
           return;
         }
 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Enhanced the Grbl controller to support UART communication without resetting the connection upon opening.
- Added logic to handle scenarios where a startup message is not received, ensuring the controller is marked as ready and initialized.
- Introduced a throttled `queryActivity` function to periodically send status queries when the connection is open.
- Improved the initialization process by checking and setting `ready` and `initialized` flags appropriately.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GrblController.js</strong><dd><code>Enhance UART communication handling and initialization logic</code></dd></summary>
<hr>

src/server/controllers/Grbl/GrblController.js

<li>Added handling for UART communication without startup message.<br> <li> Introduced <code>queryActivity</code> function with throttling.<br> <li> Improved initialization checks for <code>ready</code> and <code>initialized</code> states.<br> <li> Enhanced status report querying logic.<br>


</details>


  </td>
  <td><a href="https://github.com/cncjs/cncjs/pull/880/files#diff-4dacbcae20bbf70f0461da55cad9e5a4315835c0150c2f99d6f99bf626afa28a">+32/-5</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information