### PR TITLE
fix: resolve a regression where `api.getState` is only accessible only with an authenticated session

### DIFF
--- a/src/app/containers/Login/Login.jsx
+++ b/src/app/containers/Login/Login.jsx
@@ -1,7 +1,9 @@
 import cx from 'classnames';
 import qs from 'qs';
 import React, { PureComponent } from 'react';
+import GoogleAnalytics4 from 'react-ga4';
 import { withRouter, Redirect } from 'react-router-dom';
+import api from 'app/api';
 import Anchor from 'app/components/Anchor';
 import { Notification } from 'app/components/Notifications';
 import Space from 'app/components/Space';
@@ -40,7 +42,7 @@ class Login extends PureComponent {
         const password = this.fields.password.value;
 
         user.signin({ name, password })
-          .then(({ authenticated }) => {
+          .then(async ({ authenticated }) => {
             if (!authenticated) {
               this.setState({
                 alertMessage: i18n._('Authentication failed.'),
@@ -48,6 +50,19 @@ class Login extends PureComponent {
                 redirectToReferrer: false
               });
               return;
+            }
+
+            const res = await api.getState();
+            const { allowAnonymousUsageDataCollection } = res.body;
+            if (allowAnonymousUsageDataCollection && !GoogleAnalytics4.isInitialized) {
+              GoogleAnalytics4.initialize([
+                {
+                  trackingId: settings.analytics.trackingId,
+                  gaOptions: {
+                    cookieDomain: 'none'
+                  }
+                },
+              ]);
             }
 
             log.debug('Create and establish a WebSocket connection');

--- a/src/app/containers/Login/Login.jsx
+++ b/src/app/containers/Login/Login.jsx
@@ -52,17 +52,21 @@ class Login extends PureComponent {
               return;
             }
 
-            const res = await api.getState();
-            const { allowAnonymousUsageDataCollection } = res.body;
-            if (allowAnonymousUsageDataCollection && !GoogleAnalytics4.isInitialized) {
-              GoogleAnalytics4.initialize([
-                {
-                  trackingId: settings.analytics.trackingId,
-                  gaOptions: {
-                    cookieDomain: 'none'
-                  }
-                },
-              ]);
+            try {
+              const res = await api.getState();
+              const { allowAnonymousUsageDataCollection } = res.body || {};
+              if (allowAnonymousUsageDataCollection && !GoogleAnalytics4.isInitialized) {
+                GoogleAnalytics4.initialize([
+                  {
+                    trackingId: settings.analytics.trackingId,
+                    gaOptions: {
+                      cookieDomain: 'none'
+                    }
+                  },
+                ]);
+              }
+            } catch (error) {
+              log.error('Error initializing Google Analytics:', error);
             }
 
             log.debug('Create and establish a WebSocket connection');

--- a/src/app/index.jsx
+++ b/src/app/index.jsx
@@ -98,17 +98,21 @@ series([
     user.signin({ token: token })
       .then(async ({ authenticated, token }) => {
         if (authenticated) {
-          const res = await api.getState();
-          const { allowAnonymousUsageDataCollection } = res.body;
-          if (allowAnonymousUsageDataCollection && !GoogleAnalytics4.isInitialized) {
-            GoogleAnalytics4.initialize([
-              {
-                trackingId: settings.analytics.trackingId,
-                gaOptions: {
-                  cookieDomain: 'none'
-                }
-              },
-            ]);
+          try {
+            const res = await api.getState();
+            const { allowAnonymousUsageDataCollection } = res.body || {};
+            if (allowAnonymousUsageDataCollection && !GoogleAnalytics4.isInitialized) {
+              GoogleAnalytics4.initialize([
+                {
+                  trackingId: settings.analytics.trackingId,
+                  gaOptions: {
+                    cookieDomain: 'none'
+                  }
+                },
+              ]);
+            }
+          } catch (error) {
+            log.error('Error initializing Google Analytics:', error);
           }
 
           log.debug('Create and establish a WebSocket connection');

--- a/src/app/index.jsx
+++ b/src/app/index.jsx
@@ -72,21 +72,6 @@ series([
     }[obj.log_level || settings.log.level];
     log.setLevel(level);
   },
-  () => promisify(async (next) => {
-    const res = await api.getState();
-    const { allowAnonymousUsageDataCollection } = res.body;
-    if (allowAnonymousUsageDataCollection) {
-      GoogleAnalytics4.initialize([
-        {
-          trackingId: settings.analytics.trackingId,
-          gaOptions: {
-            cookieDomain: 'none'
-          }
-        },
-      ]);
-    }
-    next();
-  })(),
   () => promisify(next => {
     i18next
       .use(XHR)
@@ -111,8 +96,21 @@ series([
   () => promisify(next => {
     const token = store.get('session.token');
     user.signin({ token: token })
-      .then(({ authenticated, token }) => {
+      .then(async ({ authenticated, token }) => {
         if (authenticated) {
+          const res = await api.getState();
+          const { allowAnonymousUsageDataCollection } = res.body;
+          if (allowAnonymousUsageDataCollection && !GoogleAnalytics4.isInitialized) {
+            GoogleAnalytics4.initialize([
+              {
+                trackingId: settings.analytics.trackingId,
+                gaOptions: {
+                  cookieDomain: 'none'
+                }
+              },
+            ]);
+          }
+
           log.debug('Create and establish a WebSocket connection');
 
           const host = '';
@@ -127,7 +125,7 @@ series([
         }
         next();
       });
-  })()
+  })(),
 ]).then(async () => {
   log.info(`${settings.productName} ${settings.version}`);
 


### PR DESCRIPTION
Fix a regression introduced in PR #877 

___

### **Description**
- Fixed a regression where `api.getState` was only accessible with an authenticated session.
- Enhanced the login process by initializing Google Analytics if anonymous usage data collection is allowed.
- Refactored the application startup to initialize Google Analytics after successful authentication.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Login.jsx</strong><dd><code>Enhance login with Google Analytics initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/containers/Login/Login.jsx

<li>Added import for <code>GoogleAnalytics4</code> and <code>api</code>.<br> <li> Implemented asynchronous call to <code>api.getState</code> after successful login.<br> <li> Initialized Google Analytics if anonymous usage data collection is <br>allowed.<br>


</details>


  </td>
  <td><a href="https://github.com/cncjs/cncjs/pull/885/files#diff-3c310a8ad85caaf43d43f92cf6a378fce0878efc31fb555b0f96d848be1d82c8">+16/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.jsx</strong><dd><code>Refactor Google Analytics initialization on app start</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/index.jsx

<li>Removed redundant initialization of Google Analytics.<br> <li> Moved Google Analytics initialization to occur after successful <br>authentication.<br> <li> Added asynchronous call to <code>api.getState</code> for state retrieval.<br>


</details>


  </td>
  <td><a href="https://github.com/cncjs/cncjs/pull/885/files#diff-5f8d22049fec5561962e53e43d834657f76af599fac66de962b2bfa10d251d4c">+15/-17</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information