### PR TITLE
Leverage Three.js pixelRatio for crisp rendering on high-DPI displays

### DIFF
--- a/src/app/widgets/Visualizer/Visualizer.jsx
+++ b/src/app/widgets/Visualizer/Visualizer.jsx
@@ -444,6 +444,7 @@ class Visualizer extends Component {
 
       this.controls.handleResize();
 
+      this.renderer.setPixelRatio(window.devicePixelRatio || 1);
       this.renderer.setSize(width, height);
 
       // Update the scene
@@ -609,6 +610,7 @@ class Visualizer extends Component {
       this.renderer.shadowMap.enabled = true;
       this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
       this.renderer.setClearColor(new THREE.Color(colornames('white')), 1);
+      this.renderer.setPixelRatio(window.devicePixelRatio || 1);
       this.renderer.setSize(width, height);
       this.renderer.clear();
 


### PR DESCRIPTION
### **User description**
Leverage Three.js pixelRatio for crisp rendering on high-DPI displays

This trivial update configures the renderer to use window.devicePixelRatio, enabling Three.js’s built-in pixelRatio support for sharper visuals on Retina and other high-DPI screens.


___

### **PR Type**
Enhancement


___

### **Description**
- Configure Three.js renderer to use device pixel ratio

- Enable crisp rendering on high-DPI displays

- Apply pixel ratio setting during initialization and resize


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Renderer Initialization"] --> B["Set Pixel Ratio"]
  C["Resize Handler"] --> B
  B --> D["Crisp High-DPI Rendering"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Visualizer.jsx</strong><dd><code>Configure pixel ratio for high-DPI rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/widgets/Visualizer/Visualizer.jsx

<li>Add <code>setPixelRatio()</code> call during renderer initialization<br> <li> Add <code>setPixelRatio()</code> call in resize handler<br> <li> Use <code>window.devicePixelRatio</code> with fallback to 1


</details>


  </td>
  <td><a href="https://github.com/cncjs/cncjs/pull/928/files#diff-1bb06f5eab55d3a68f453b4be9784610723d7fee914c4005580b29380e522777">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>