### PR TITLE
fix: align machine limits, pivot, and orbit center with machine profiles

### DIFF
--- a/src/app/i18n/cs/resource.json
+++ b/src/app/i18n/cs/resource.json
@@ -644,5 +644,6 @@
   "{{value}} {{- units}}": "{{value}} {{- units}}",
   "Clearance Z: {{value}} {{- units}}": "Výška přejezdu Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Počáteční Z: {{value}} {{- units}}",
-  "End Z: {{value}} {{- units}}": "Koncové Z: {{value}} {{- units}}"
+  "End Z: {{value}} {{- units}}": "Koncové Z: {{value}} {{- units}}",
+  "None": "Žádný"
 }

--- a/src/app/i18n/de/resource.json
+++ b/src/app/i18n/de/resource.json
@@ -642,5 +642,6 @@
   "{{value}} {{- units}}": "{{value}} {{- units}}",
   "Clearance Z: {{value}} {{- units}}": "Freifahrhöhe Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Start-Z: {{value}} {{- units}}",
-  "End Z: {{value}} {{- units}}": "End-Z: {{value}} {{- units}}"
+  "End Z: {{value}} {{- units}}": "End-Z: {{value}} {{- units}}",
+  "None": "Keine"
 }

--- a/src/app/i18n/en/resource.json
+++ b/src/app/i18n/en/resource.json
@@ -642,5 +642,6 @@
   "{{value}} {{- units}}": "{{value}} {{- units}}",
   "Clearance Z: {{value}} {{- units}}": "Clearance Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Start Z: {{value}} {{- units}}",
-  "End Z: {{value}} {{- units}}": "End Z: {{value}} {{- units}}"
+  "End Z: {{value}} {{- units}}": "End Z: {{value}} {{- units}}",
+  "None": "None"
 }

--- a/src/app/i18n/es/resource.json
+++ b/src/app/i18n/es/resource.json
@@ -643,5 +643,6 @@
   "{{value}} {{- units}}": "{{value}} {{- units}}",
   "Clearance Z: {{value}} {{- units}}": "Z de separación: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Z inicial: {{value}} {{- units}}",
-  "End Z: {{value}} {{- units}}": "Z final: {{value}} {{- units}}"
+  "End Z: {{value}} {{- units}}": "Z final: {{value}} {{- units}}",
+  "None": "Ninguno"
 }

--- a/src/app/i18n/fr/resource.json
+++ b/src/app/i18n/fr/resource.json
@@ -643,5 +643,6 @@
   "{{value}} {{- units}}": "{{value}} {{- units}}",
   "Clearance Z: {{value}} {{- units}}": "Z de dégagement : {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Z de départ : {{value}} {{- units}}",
-  "End Z: {{value}} {{- units}}": "Z de fin : {{value}} {{- units}}"
+  "End Z: {{value}} {{- units}}": "Z de fin : {{value}} {{- units}}",
+  "None": "Aucun"
 }

--- a/src/app/i18n/hu/resource.json
+++ b/src/app/i18n/hu/resource.json
@@ -642,5 +642,6 @@
   "{{value}} {{- units}}": "{{value}} {{- units}}",
   "Clearance Z: {{value}} {{- units}}": "Z biztonsági magasság: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Kezdeti Z: {{value}} {{- units}}",
-  "End Z: {{value}} {{- units}}": "Végső Z: {{value}} {{- units}}"
+  "End Z: {{value}} {{- units}}": "Végső Z: {{value}} {{- units}}",
+  "None": "Nincs"
 }

--- a/src/app/i18n/it/resource.json
+++ b/src/app/i18n/it/resource.json
@@ -643,5 +643,6 @@
   "{{value}} {{- units}}": "{{value}} {{- units}}",
   "Clearance Z: {{value}} {{- units}}": "Z di sicurezza: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Z iniziale: {{value}} {{- units}}",
-  "End Z: {{value}} {{- units}}": "Z finale: {{value}} {{- units}}"
+  "End Z: {{value}} {{- units}}": "Z finale: {{value}} {{- units}}",
+  "None": "Nessuno"
 }

--- a/src/app/i18n/ja/resource.json
+++ b/src/app/i18n/ja/resource.json
@@ -641,5 +641,6 @@
   "{{value}} {{- units}}": "{{value}} {{- units}}",
   "Clearance Z: {{value}} {{- units}}": "クリアランスZ: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "開始Z: {{value}} {{- units}}",
-  "End Z: {{value}} {{- units}}": "終了Z: {{value}} {{- units}}"
+  "End Z: {{value}} {{- units}}": "終了Z: {{value}} {{- units}}",
+  "None": "なし"
 }

--- a/src/app/i18n/nb/resource.json
+++ b/src/app/i18n/nb/resource.json
@@ -642,5 +642,6 @@
   "{{value}} {{- units}}": "{{value}} {{- units}}",
   "Clearance Z: {{value}} {{- units}}": "Frihøyde Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Start-Z: {{value}} {{- units}}",
-  "End Z: {{value}} {{- units}}": "Slutt-Z: {{value}} {{- units}}"
+  "End Z: {{value}} {{- units}}": "Slutt-Z: {{value}} {{- units}}",
+  "None": "Ingen"
 }

--- a/src/app/i18n/nl/resource.json
+++ b/src/app/i18n/nl/resource.json
@@ -642,5 +642,6 @@
   "{{value}} {{- units}}": "{{value}} {{- units}}",
   "Clearance Z: {{value}} {{- units}}": "Vrijloophoogte Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Start-Z: {{value}} {{- units}}",
-  "End Z: {{value}} {{- units}}": "Eind-Z: {{value}} {{- units}}"
+  "End Z: {{value}} {{- units}}": "Eind-Z: {{value}} {{- units}}",
+  "None": "Geen"
 }

--- a/src/app/i18n/pt-br/resource.json
+++ b/src/app/i18n/pt-br/resource.json
@@ -643,5 +643,6 @@
   "{{value}} {{- units}}": "{{value}} {{- units}}",
   "Clearance Z: {{value}} {{- units}}": "Z de folga: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Z inicial: {{value}} {{- units}}",
-  "End Z: {{value}} {{- units}}": "Z final: {{value}} {{- units}}"
+  "End Z: {{value}} {{- units}}": "Z final: {{value}} {{- units}}",
+  "None": "Nenhum"
 }

--- a/src/app/i18n/pt/resource.json
+++ b/src/app/i18n/pt/resource.json
@@ -643,5 +643,6 @@
   "{{value}} {{- units}}": "{{value}} {{- units}}",
   "Clearance Z: {{value}} {{- units}}": "Z de folga: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Z inicial: {{value}} {{- units}}",
-  "End Z: {{value}} {{- units}}": "Z final: {{value}} {{- units}}"
+  "End Z: {{value}} {{- units}}": "Z final: {{value}} {{- units}}",
+  "None": "Nenhum"
 }

--- a/src/app/i18n/ru/resource.json
+++ b/src/app/i18n/ru/resource.json
@@ -644,5 +644,6 @@
   "{{value}} {{- units}}": "{{value}} {{- units}}",
   "Clearance Z: {{value}} {{- units}}": "Высота подъёма Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Начальная Z: {{value}} {{- units}}",
-  "End Z: {{value}} {{- units}}": "Конечная Z: {{value}} {{- units}}"
+  "End Z: {{value}} {{- units}}": "Конечная Z: {{value}} {{- units}}",
+  "None": "Нет"
 }

--- a/src/app/i18n/tr/resource.json
+++ b/src/app/i18n/tr/resource.json
@@ -642,5 +642,6 @@
   "{{value}} {{- units}}": "{{value}} {{- units}}",
   "Clearance Z: {{value}} {{- units}}": "Güvenlik Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Başlangıç Z: {{value}} {{- units}}",
-  "End Z: {{value}} {{- units}}": "Bitiş Z: {{value}} {{- units}}"
+  "End Z: {{value}} {{- units}}": "Bitiş Z: {{value}} {{- units}}",
+  "None": "Yok"
 }

--- a/src/app/i18n/uk/resource.json
+++ b/src/app/i18n/uk/resource.json
@@ -644,5 +644,6 @@
   "{{value}} {{- units}}": "{{value}} {{- units}}",
   "Clearance Z: {{value}} {{- units}}": "Висота підйому Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Початкова Z: {{value}} {{- units}}",
-  "End Z: {{value}} {{- units}}": "Кінцева Z: {{value}} {{- units}}"
+  "End Z: {{value}} {{- units}}": "Кінцева Z: {{value}} {{- units}}",
+  "None": "Немає"
 }

--- a/src/app/i18n/zh-cn/resource.json
+++ b/src/app/i18n/zh-cn/resource.json
@@ -641,5 +641,6 @@
   "{{value}} {{- units}}": "{{value}} {{- units}}",
   "Clearance Z: {{value}} {{- units}}": "安全高度Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "起始Z: {{value}} {{- units}}",
-  "End Z: {{value}} {{- units}}": "终止Z: {{value}} {{- units}}"
+  "End Z: {{value}} {{- units}}": "终止Z: {{value}} {{- units}}",
+  "None": "无"
 }

--- a/src/app/i18n/zh-tw/resource.json
+++ b/src/app/i18n/zh-tw/resource.json
@@ -641,5 +641,6 @@
   "{{value}} {{- units}}": "{{value}} {{- units}}",
   "Clearance Z: {{value}} {{- units}}": "安全高度Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "起始Z: {{value}} {{- units}}",
-  "End Z: {{value}} {{- units}}": "終止Z: {{value}} {{- units}}"
+  "End Z: {{value}} {{- units}}": "終止Z: {{value}} {{- units}}",
+  "None": "無"
 }

--- a/src/app/widgets/Visualizer/SecondaryToolbar.jsx
+++ b/src/app/widgets/Visualizer/SecondaryToolbar.jsx
@@ -32,6 +32,9 @@ import {
   CAMERA_MODE_ROTATE
 } from './constants';
 
+// Sentinel eventKey for the "None" item in the machine-profile dropdown.
+const CLEAR_MACHINE_PROFILE = '__clear__';
+
 const IconButton = styled(Button)`
     display: inline-block;
     padding: 8px;
@@ -135,6 +138,13 @@ class SecondaryToolbar extends PureComponent {
       if (machineProfile) {
         store.replace('workspace.machineProfile', machineProfile);
       }
+    };
+
+    clearMachineProfile = () => {
+      // Match the shape used by Settings.jsx when a profile is deleted, so
+      // every reader (Visualizer changeMachineProfile, this toolbar's
+      // updateMachineProfileFromStore) handles "no profile" the same way.
+      store.replace('workspace.machineProfile', { id: null });
     };
 
     subscribe() {
@@ -388,8 +398,11 @@ class SecondaryToolbar extends PureComponent {
                   dropup
                   pullRight
                   onSelect={(eventKey) => {
-                    const id = eventKey;
-                    this.changeMachineProfileById(id);
+                    if (eventKey === CLEAR_MACHINE_PROFILE) {
+                      this.clearMachineProfile();
+                      return;
+                    }
+                    this.changeMachineProfileById(eventKey);
                   }}
                 >
                   <Dropdown.Toggle
@@ -414,10 +427,17 @@ class SecondaryToolbar extends PureComponent {
                       i18n._('No machine profile selected')
                     )}
                   </Dropdown.Toggle>
-                  <Dropdown.Menu>
+                  <Dropdown.Menu style={{ maxHeight: 320, overflowY: 'auto' }}>
                     <MenuItem header>
                       {i18n._('Machine Profiles')}
                     </MenuItem>
+                    <MenuItem
+                      active={!selectedMachineProfile}
+                      eventKey={CLEAR_MACHINE_PROFILE}
+                    >
+                      {i18n._('None')}
+                    </MenuItem>
+                    <MenuItem divider />
                     {machineProfiles.map(({ id, name }) => (
                       <MenuItem
                         active={id === selectedMachineProfileId}

--- a/src/app/widgets/Visualizer/Visualizer.jsx
+++ b/src/app/widgets/Visualizer/Visualizer.jsx
@@ -74,7 +74,11 @@ class Visualizer extends Component {
       z: 0
     };
 
-    machineProfile = store.get('workspace.machineProfile');
+    // Initialized to null so the first changeMachineProfile() call in
+    // componentDidMount detects a difference against the store value and runs
+    // the full pivot/rebuild pipeline. Pre-hydrating from the store here would
+    // make _isEqual short-circuit and leave pivotPoint at (0, 0, 0).
+    machineProfile = null;
 
     group = new THREE.Group();
 
@@ -98,6 +102,36 @@ class Visualizer extends Component {
       this.resizeRenderer();
     }, 32); // 60hz
 
+    // Pivot policy. The pivot determines the "machine - pivot" frame the
+    // whole scene is rendered in: limits, cutting tool, probe viz, gcode
+    // toolpath, and (via rebuildCoordinateSystems) grid + axes all sit at
+    // "machine_coords - pivot" so the visible workspace center is at world
+    // origin and TrackballControls' default target = (0, 0, 0) orbits that
+    // visible center.
+    //
+    // Pivot is set by this method, load(), and unload(). Combined behavior:
+    //
+    //   Scenario                                | Pivot after        | Gcode position
+    //   ----------------------------------------|--------------------|----------------------
+    //   Reload, profile saved, no gcode         | profile center     | -
+    //   Manual profile selection, no gcode      | profile center     | -
+    //   Manual profile selection, gcode loaded  | gcode bbox center  | at world origin
+    //   Profile removed, no gcode               | (0, 0, 0)          | -
+    //   Profile removed, gcode loaded           | gcode bbox center  | at world origin
+    //   Load gcode                              | gcode bbox center  | at world origin
+    //   Unload gcode, profile selected          | profile center     | -
+    //   Unload gcode, no profile                | (0, 0, 0)          | -
+    //
+    // For the two "gcode loaded" rows above the pivot was already at the
+    // gcode bbox center (set by load()) and is intentionally left alone, so
+    // the toolpath stays visually centered in the viewport across profile
+    // changes; only the limits/grid rebuild for the new profile dimensions.
+    //
+    // The `!this.gcodeVisualizer` check distinguishes the two states.
+    // `this.gcodeVisualizer` is the GCodeVisualizer instance — null until
+    // load() runs, nulled again by unload() — so it is a direct local source
+    // of truth and works the same way regardless of who triggered
+    // changeMachineProfile (mount, store change, etc.).
     changeMachineProfile = () => {
       const machineProfile = store.get('workspace.machineProfile');
 
@@ -109,7 +143,9 @@ class Visualizer extends Component {
 
       // Profile removed — reset to defaults and return
       if (!machineProfile) {
-        this.pivotPoint.set(0, 0, 0);
+        if (!this.gcodeVisualizer) {
+          this.pivotPoint.set(0, 0, 0);
+        }
         this.updateCuttingToolPosition();
         this.updateCuttingPointerPosition();
         this.updateLimitsPosition();
@@ -134,10 +170,13 @@ class Visualizer extends Component {
       this.limits.visible = state.objects.limits.visible;
       this.group.add(this.limits);
 
-      // Set pivot to the center of the machine profile work area (XY only; Z origin stays at 0)
-      const centerX = (xmin + xmax) / 2;
-      const centerY = (ymin + ymax) / 2;
-      this.pivotPoint.set(centerX, centerY, 0);
+      // Set pivot to the center of the machine profile work area (XY only).
+      // Skipped when gcode is loaded so the toolpath stays centered.
+      if (!this.gcodeVisualizer) {
+        const centerX = (xmin + xmax) / 2;
+        const centerY = (ymin + ymax) / 2;
+        this.pivotPoint.set(centerX, centerY, 0);
+      }
 
       this.updateCuttingToolPosition();
       this.updateCuttingPointerPosition();
@@ -180,7 +219,7 @@ class Visualizer extends Component {
       this.cuttingTool = null;
       this.cuttingPointer = null;
       this.limits = null;
-      this.visualizer = null;
+      this.gcodeVisualizer = null;
     }
 
     componentDidMount() {
@@ -192,6 +231,12 @@ class Visualizer extends Component {
         this.createScene(el);
         this.resizeRenderer();
       }
+
+      // Apply any machine profile already in the store (e.g., hydrated from
+      // localStorage on page reload). The store 'change' listener above only
+      // fires on subsequent updates, so without this call the saved profile
+      // never reaches the scene until the user re-selects it.
+      this.changeMachineProfile();
     }
 
     componentDidUpdate(prevProps) {
@@ -209,10 +254,10 @@ class Visualizer extends Component {
         needUpdateScene = true;
       }
 
-      // Update visualizer's frame index
-      if (this.visualizer) {
+      // Update gcode visualizer's frame index
+      if (this.gcodeVisualizer) {
         const frameIndex = state.gcode.sent;
-        this.visualizer.setFrameIndex(frameIndex);
+        this.gcodeVisualizer.setFrameIndex(frameIndex);
       }
 
       // Projection
@@ -763,24 +808,37 @@ class Visualizer extends Component {
         }
       });
 
+      // Grid/axes geometry is built at raw machine coords; shift each group by
+      // -pivotPoint so it shares the same frame as the limits, cutting tool,
+      // probe visualization, and gcode toolpath (all of which render at
+      // "machine coords - pivotPoint").
+      const pp = this.pivotPoint.get();
+      const positionAtPivot = (group) => {
+        group.position.set(-pp.x, -pp.y, -pp.z);
+      };
+
       const imperialCoordinateSystem = this.createCoordinateSystem(IMPERIAL_UNITS);
       imperialCoordinateSystem.name = 'ImperialCoordinateSystem';
       imperialCoordinateSystem.visible = objects.coordinateSystem.visible && (units === IMPERIAL_UNITS);
+      positionAtPivot(imperialCoordinateSystem);
       this.group.add(imperialCoordinateSystem);
 
       const metricCoordinateSystem = this.createCoordinateSystem(METRIC_UNITS);
       metricCoordinateSystem.name = 'MetricCoordinateSystem';
       metricCoordinateSystem.visible = objects.coordinateSystem.visible && (units === METRIC_UNITS);
+      positionAtPivot(metricCoordinateSystem);
       this.group.add(metricCoordinateSystem);
 
       const imperialGridLineNumbers = this.createGridLineNumbers(IMPERIAL_UNITS);
       imperialGridLineNumbers.name = 'ImperialGridLineNumbers';
       imperialGridLineNumbers.visible = objects.gridLineNumbers.visible && (units === IMPERIAL_UNITS);
+      positionAtPivot(imperialGridLineNumbers);
       this.group.add(imperialGridLineNumbers);
 
       const metricGridLineNumbers = this.createGridLineNumbers(METRIC_UNITS);
       metricGridLineNumbers.name = 'MetricGridLineNumbers';
       metricGridLineNumbers.visible = objects.gridLineNumbers.visible && (units === METRIC_UNITS);
+      positionAtPivot(metricGridLineNumbers);
       this.group.add(metricGridLineNumbers);
     }
 
@@ -852,37 +910,10 @@ class Visualizer extends Component {
         this.scene.add(light);
       }
 
-      { // Imperial Coordinate System
-        const visible = objects.coordinateSystem.visible;
-        const imperialCoordinateSystem = this.createCoordinateSystem(IMPERIAL_UNITS);
-        imperialCoordinateSystem.name = 'ImperialCoordinateSystem';
-        imperialCoordinateSystem.visible = visible && (units === IMPERIAL_UNITS);
-        this.group.add(imperialCoordinateSystem);
-      }
-
-      { // Metric Coordinate System
-        const visible = objects.coordinateSystem.visible;
-        const metricCoordinateSystem = this.createCoordinateSystem(METRIC_UNITS);
-        metricCoordinateSystem.name = 'MetricCoordinateSystem';
-        metricCoordinateSystem.visible = visible && (units === METRIC_UNITS);
-        this.group.add(metricCoordinateSystem);
-      }
-
-      { // Imperial Grid Line Numbers
-        const visible = objects.gridLineNumbers.visible;
-        const imperialGridLineNumbers = this.createGridLineNumbers(IMPERIAL_UNITS);
-        imperialGridLineNumbers.name = 'ImperialGridLineNumbers';
-        imperialGridLineNumbers.visible = visible && (units === IMPERIAL_UNITS);
-        this.group.add(imperialGridLineNumbers);
-      }
-
-      { // Metric Grid Line Numbers
-        const visible = objects.gridLineNumbers.visible;
-        const metricGridLineNumbers = this.createGridLineNumbers(METRIC_UNITS);
-        metricGridLineNumbers.name = 'MetricGridLineNumbers';
-        metricGridLineNumbers.visible = visible && (units === METRIC_UNITS);
-        this.group.add(metricGridLineNumbers);
-      }
+      // Coordinate systems and grid line numbers (Imperial + Metric) are
+      // created via rebuildCoordinateSystems so the initial render uses the
+      // same pivot-shifted frame as later rebuilds.
+      this.rebuildCoordinateSystems();
 
       { // Cutting Tool
         Promise.all([
@@ -921,6 +952,13 @@ class Visualizer extends Component {
           this.cuttingTool.visible = objects.cuttingTool.visible;
 
           this.group.add(this.cuttingTool);
+
+          // The STL/texture load is async, so the tool may be added to the
+          // group after changeMachineProfile() has already run during mount.
+          // Sync its position to the current pivot/WPos so it lands at the
+          // correct spot instead of the default (0, 0, 0) (which would be the
+          // visible workspace center under any non-trivial machine profile).
+          this.updateCuttingToolPosition();
 
           // Update the scene
           this.updateScene();
@@ -1150,14 +1188,14 @@ class Visualizer extends Component {
         return;
       }
 
+      // Limits represent the machine's fixed envelope and stay anchored to the
+      // grid regardless of the active work coordinate system.
       const limits = _get(this.machineProfile, 'limits');
       const { xmin = 0, xmax = 0, ymin = 0, ymax = 0, zmin = 0, zmax = 0 } = { ...limits };
       const pivotPoint = this.pivotPoint.get();
-      const { x: mpox, y: mpoy, z: mpoz } = this.machinePosition;
-      const { x: wpox, y: wpoy, z: wpoz } = this.workPosition;
-      const x0 = ((xmin + xmax) / 2) - (mpox - wpox) - pivotPoint.x;
-      const y0 = ((ymin + ymax) / 2) - (mpoy - wpoy) - pivotPoint.y;
-      const z0 = ((zmin + zmax) / 2) - (mpoz - wpoz) - pivotPoint.z;
+      const x0 = ((xmin + xmax) / 2) - pivotPoint.x;
+      const y0 = ((ymin + ymax) / 2) - pivotPoint.y;
+      const z0 = ((zmin + zmax) / 2) - pivotPoint.z;
 
       this.limits.position.set(x0, y0, z0);
     }
@@ -1195,9 +1233,9 @@ class Visualizer extends Component {
       // Remove previous G-code object
       this.unload();
 
-      this.visualizer = new GCodeVisualizer();
+      this.gcodeVisualizer = new GCodeVisualizer();
 
-      const obj = this.visualizer.render(gcode);
+      const obj = this.gcodeVisualizer.render(gcode);
       obj.name = 'Visualizer';
       this.group.add(obj);
 
@@ -1213,6 +1251,14 @@ class Visualizer extends Component {
 
       // Set the pivot point to the center of the loaded object
       this.pivotPoint.set(center.x, center.y, center.z);
+
+      // Explicitly anchor the gcode mesh so its bounding-box center lands at
+      // world origin, independent of the pivot-delta callback's translation
+      // history. Without this, when unload() leaves the pivot at the machine
+      // profile's center (rather than (0, 0, 0)), the delta from
+      // profile_center → gcode_center would land the mesh at world
+      // profile_center instead of world origin.
+      obj.position.set(-center.x, -center.y, -center.z);
 
       // Update position
       this.updateCuttingToolPosition();
@@ -1240,19 +1286,35 @@ class Visualizer extends Component {
         this.group.remove(visualizerObject);
       }
 
-      if (this.visualizer) {
-        this.visualizer = null;
+      if (this.gcodeVisualizer) {
+        this.gcodeVisualizer = null;
       }
 
       if (this.pivotPoint) {
-        // Set the pivot point to the origin point (0, 0, 0)
-        this.pivotPoint.set(0, 0, 0);
+        // Reset pivot to the machine profile's XY center (or origin if no
+        // profile) so the scene stays in the same "machine - pivot" frame as
+        // changeMachineProfile produces. This keeps the visible workspace
+        // centered at world origin and the orbit pivot (controls.target =
+        // (0, 0, 0)) at the visible center after unloading gcode.
+        if (!this.machineProfile) {
+          this.pivotPoint.set(0, 0, 0);
+        } else {
+          const limits = _get(this.machineProfile, 'limits');
+          const { xmin = 0, xmax = 0, ymin = 0, ymax = 0 } = { ...limits };
+          const centerX = (xmin + xmax) / 2;
+          const centerY = (ymin + ymax) / 2;
+          this.pivotPoint.set(centerX, centerY, 0);
+        }
 
         // Update positions after resetting pivot point
         this.updateCuttingToolPosition();
         this.updateCuttingPointerPosition();
         this.updateLimitsPosition();
         this.updateProbeVisualizationPosition();
+
+        if (this.group) {
+          this.rebuildCoordinateSystems();
+        }
       }
 
       if (this.controls) {

--- a/src/app/widgets/Visualizer/Visualizer.jsx
+++ b/src/app/widgets/Visualizer/Visualizer.jsx
@@ -17,6 +17,7 @@ import CombinedCamera from 'app/lib/three/CombinedCamera';
 import TrackballControls from 'app/lib/three/TrackballControls';
 import * as WebGL from 'app/lib/three/WebGL';
 import log from 'app/lib/log';
+import { mapValueToUnits } from 'app/lib/units';
 import store from 'app/store';
 import { getBoundingBox, loadSTL, loadTexture } from './helpers';
 import Viewport from './Viewport';
@@ -767,7 +768,9 @@ class Visualizer extends Component {
             y: textOffset,
             z: 0,
             size: textSize,
-            text: Math.round(x),
+            // Scene coords are mm; mapValueToUnits converts and trims
+            // trailing zeros (e.g. 25.4 mm → 1 in, 10 mm → 10 mm).
+            text: mapValueToUnits(x, units),
             textAlign: 'center',
             textBaseline: 'bottom',
             color: colornames('red'),
@@ -784,7 +787,7 @@ class Visualizer extends Component {
             y,
             z: 0,
             size: textSize,
-            text: Math.round(y),
+            text: mapValueToUnits(y, units),
             textAlign: 'right',
             textBaseline: 'middle',
             color: colornames('green'),

--- a/src/package.json
+++ b/src/package.json
@@ -44,7 +44,7 @@
     "jsonwebtoken": "~9.0.0",
     "lodash": "~4.17.11",
     "method-override": "~3.0.0",
-    "minimatch": "~3.0.4",
+    "minimatch": "~3.1.4",
     "mkdirp": "~0.5.1",
     "morgan": "~1.9.1",
     "range_check": "~1.4.0",


### PR DESCRIPTION
## Summary

Fixes #971. A chain of regressions from v1.11.0 (PR #959, the autolevel rework) where the Visualizer was reworked to render at machine coordinates with pivot shifting. The bugs only became visible with non-symmetric machine profiles (negative-coord ranges like X: -300..0), but a chain of subtle state-transition issues meant page reloads, profile switches, and gcode load/unload also ended up in inconsistent coordinate frames.

## What changed

- **\`updateLimitsPosition\`**: drop the \`(mpox - wpox)\` WCS term — the machine envelope is fixed and shouldn't follow the active work coord system
- **\`rebuildCoordinateSystems\`**: position grid/axes at \`-pivotPoint\` so they share the "machine − pivot" frame as everything else
- **\`createScene\`**: replace four inline coord-system blocks with a single \`rebuildCoordinateSystems()\` call
- **\`componentDidMount\`**: explicitly call \`changeMachineProfile()\` after \`createScene\` — \`store.on('change')\` does not fire on initial localStorage hydration
- **\`machineProfile\` field**: initialize to \`null\` instead of pre-hydrating from store, so the mount-time \`changeMachineProfile()\` call does not short-circuit on \`_isEqual\`
- **Cutting tool**: call \`updateCuttingToolPosition()\` inside the STL load Promise resolver so the async-loaded mesh lands at the correct WPos
- **\`unload\`**: reset pivot to the machine profile center (or \`(0, 0, 0)\` if no profile) so the visible workspace stays centered after unloading gcode
- **\`changeMachineProfile\`**: skip \`pivotPoint.set()\` when gcode is loaded so the toolpath stays centered across profile changes; only limits/grid rebuild for the new profile dimensions
- **\`load\`**: explicitly anchor gcode mesh at \`-bbox_center\`, independent of pivot delta history
- Rename \`this.visualizer\` → \`this.gcodeVisualizer\` to disambiguate from the wrapper's React ref of the same name

A behavior matrix documenting the combined pivot policy is added as a comment block above \`changeMachineProfile\`.

## Test plan

No automated tests exist for the Visualizer (\`yarn test\` still passes 233/233 unrelated tests). Manual verification with \`yarn dev\`:

- [x] No machine profile: grid centered at world origin, mouse drag orbits the center
- [x] Positive-coord profile (e.g., Shapeoko 3, X: 0..425): grid + limits aligned, orbit centers on workspace
- [x] **Negative-coord profile** (X: -300..0, Y: -300..0): grid + limits aligned, orbit centers on visible workspace
- [ ] After \`G10 L20 P1 X300 Y300\`: limits cuboid stays anchored to grid (does not drift)
  -> `G10 L20 P1 X300 Y300` is not verified
- [x] **Page reload with negative-coord profile saved**: dropdown shows the profile, grid/limits aligned, orbit centers on visible workspace, cutting tool at machine origin (workspace corner)
- [x] Switch profiles back and forth (positive ↔ negative ↔ none): grid/limits stay aligned each transition
- [x] Load a gcode file: toolpath renders centered in viewport
- [x] Switch profile while gcode is loaded: toolpath stays centered, only limits/grid rebuild
- [x] Unload gcode (with profile): visible workspace re-centers; orbit pivot at visible center
- [x] Unload gcode (no profile): default symmetric grid centered
- [x] AutoLevel widget: probe overlay aligns with grid in all profile configurations
- [x] View presets (Top/Front/3D/Left/Right): camera centers on workspace
- [x] Imperial ↔ metric toggle: grid spacing updates, alignment preserved
