### PR TITLE
Adds authDisabled config for anonymous access

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,10 +176,13 @@ Instead of passing command line options for `--watch-directory`, `--access-token
     ],
     "watchDirectory": "/path/to/dir",
     "accessTokenLifetime": "30d",
+    "authDisabled": false,
     "allowRemoteAccess": false,
     "controller": ""
 }
 ```
+
+Set `"authDisabled": true` only when running cncjs on a trusted local network. This disables the normal sign-in requirement and is not recommended for servers exposed to untrusted clients.
 
 To troubleshoot issues, run:
 ```
@@ -223,6 +226,7 @@ See https://github.com/cncjs/cncjs/issues/242#issuecomment-352294549 for a detai
   ],
   "watchDirectory": "/path/to/dir",
   "accessTokenLifetime": "30d",
+  "authDisabled": false,
   "allowRemoteAccess": false,
   "controller": "",
   "state": {

--- a/src/server/access-control.js
+++ b/src/server/access-control.js
@@ -36,6 +36,11 @@ export const authorizeIPAddress = (ipaddr) => new Promise((resolve, reject) => {
 });
 
 export const validateUser = (user) => new Promise((resolve, reject) => {
+  if (settings.authDisabled) {
+    resolve();
+    return;
+  }
+
   const { id = null, name = null } = { ...user };
 
   const users = ensureArray(config.get('users'))

--- a/src/server/api/__tests__/api.users.test.js
+++ b/src/server/api/__tests__/api.users.test.js
@@ -1,0 +1,135 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import expressJwt from 'express-jwt';
+import jwt from 'jsonwebtoken';
+import app from '../../app';
+import settings from '../../config/settings';
+import * as usersApi from '../api.users';
+import config from '../../services/configstore';
+
+describe('authDisabled signin flow', () => {
+  let configFile = '';
+  let originalAuthDisabled = false;
+  let originalSecret = '';
+
+  beforeAll(() => {
+    originalAuthDisabled = settings.authDisabled;
+    originalSecret = settings.secret;
+
+    configFile = path.join(os.tmpdir(), `cncjs-auth-disabled-${Date.now()}.json`);
+    fs.writeFileSync(configFile, JSON.stringify({}), 'utf8');
+
+    config.load(configFile);
+    config.set('secret', 'test-secret');
+    config.set('authDisabled', true);
+
+    settings.secret = 'test-secret';
+    settings.authDisabled = true;
+  });
+
+  afterAll(() => {
+    settings.authDisabled = originalAuthDisabled;
+    settings.secret = originalSecret;
+
+    fs.unwatchFile(configFile);
+    config.watcher = null;
+    fs.unlinkSync(configFile);
+  });
+
+  test('allows /api/signin to return an anonymous token when authDisabled=true', async () => {
+    const req = {
+      body: {}
+    };
+    const res = {
+      send: jest.fn(),
+      status: jest.fn()
+    };
+
+    usersApi.signin(req, res);
+
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.send).toHaveBeenCalledTimes(1);
+
+    const body = res.send.mock.calls[0][0];
+    expect(body.enabled).toBe(false);
+    expect(body.name).toBe('anonymous');
+    expect(typeof body.token).toBe('string');
+    expect(body.token.length).toBeGreaterThan(0);
+
+    const payload = jwt.verify(body.token, settings.secret);
+    expect(payload.id).toBe('anonymous');
+    expect(payload.name).toBe('anonymous');
+  });
+});
+
+describe('authDisabled signin flow', () => {
+  let configFile = '';
+  let originalAuthDisabled = false;
+  let originalSecret = '';
+  let originalSessionPath = '';
+  let sessionPath = '';
+
+  beforeAll(() => {
+    originalAuthDisabled = settings.authDisabled;
+    originalSecret = settings.secret;
+    originalSessionPath = settings.middleware.session.path;
+
+    config.watcher = null;
+    configFile = path.join(os.tmpdir(), `cncjs-auth-middleware-${Date.now()}.json`);
+    sessionPath = path.join(os.tmpdir(), `cncjs-sessions-${Date.now()}`);
+    fs.writeFileSync(configFile, JSON.stringify({}), 'utf8');
+
+    config.load(configFile);
+    config.set('secret', 'test-secret');
+
+    settings.secret = 'test-secret';
+    settings.authDisabled = false;
+    settings.middleware.session.path = sessionPath;
+  });
+
+  afterAll(() => {
+    settings.authDisabled = originalAuthDisabled;
+    settings.secret = originalSecret;
+    settings.middleware.session.path = originalSessionPath;
+
+    fs.unwatchFile(configFile);
+    config.watcher = null;
+    fs.unlinkSync(configFile);
+    fs.rmSync(sessionPath, { force: true, recursive: true });
+  });
+
+  test('rejects tokenless protected routes when authDisabled=false', async () => {
+    const instance = app();
+    const middlewareLayer = instance._router.stack.find((layer) => {
+      return typeof layer.handle === 'function' &&
+        layer.handle.length === 4 &&
+        layer.handle.toString().includes('UnauthorizedError');
+    });
+
+    expect(middlewareLayer).toBeTruthy();
+
+    const err = new expressJwt.UnauthorizedError('credentials_required', {
+      message: 'No authorization token was found'
+    });
+    const req = {
+      body: {},
+      connection: {
+        remoteAddress: '127.0.0.1'
+      },
+      ip: '127.0.0.1',
+      path: '/api/state'
+    };
+    const res = {
+      end: jest.fn(),
+      status: jest.fn().mockReturnThis()
+    };
+    const next = jest.fn();
+
+    await middlewareLayer.handle(err, req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.end).toHaveBeenCalledWith('Forbidden Access');
+  });
+});

--- a/src/server/api/api.users.js
+++ b/src/server/api/api.users.js
@@ -20,6 +20,10 @@ import {
 
 const log = logger('api:users');
 const CONFIG_KEY = 'users';
+const ANON_USER = {
+  id: 'anonymous',
+  name: 'anonymous'
+};
 
 // Generate access token
 // https://github.com/auth0/node-jsonwebtoken#jwtsignpayload-secretorprivatekey-options-callback
@@ -70,6 +74,17 @@ export const signin = (req, res) => {
   const enabledUsers = users.filter(user => {
     return user.enabled;
   });
+
+  if (settings.authDisabled) {
+    const payload = { ...ANON_USER };
+    const token = generateAccessToken(payload, settings.secret); // generate access token
+    res.send({
+      enabled: false, // session is disabled
+      token: token,
+      name: ANON_USER.name
+    });
+    return;
+  }
 
   if (enabledUsers.length === 0) {
     const user = { id: '', name: '' };

--- a/src/server/config/settings.base.js
+++ b/src/server/config/settings.base.js
@@ -24,6 +24,9 @@ export default {
   // Allow Remote Access
   allowRemoteAccess: false,
 
+  // Disable authentication
+  authDisabled: false,
+
   // Express view engine
   view: {
     // Set html (w/o dot) as the default extension

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -101,6 +101,11 @@ const createServer = (options, callback) => {
     }
   }
 
+  { // authDisabled
+    const authDisabled = config.get('authDisabled', false);
+    set(settings, 'authDisabled', !!authDisabled);
+  }
+
   const { port = 0, host, backlog } = options;
   const mountPoints = uniqWith([
     ...ensureArray(options.mountPoints),

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -89,6 +89,11 @@ const createServer = (options, callback) => {
     }
   }
 
+  { // authDisabled
+    const authDisabled = config.get('authDisabled', false);
+    set(settings, 'authDisabled', !!authDisabled);
+  }
+
   { // allowRemoteAccess
     const allowRemoteAccess = options.allowRemoteAccess || config.get('allowRemoteAccess', false);
 
@@ -96,14 +101,12 @@ const createServer = (options, callback) => {
       if (size(config.get('users')) === 0) {
         log.warn('You\'ve enabled remote access to the server. It\'s recommended to create an user account to protect against malicious attacks.');
       }
+      if (settings.authDisabled) {
+        log.warn('Authentication is disabled while remote access is enabled. This configuration is unsafe on untrusted networks.');
+      }
 
       set(settings, 'allowRemoteAccess', allowRemoteAccess);
     }
-  }
-
-  { // authDisabled
-    const authDisabled = config.get('authDisabled', false);
-    set(settings, 'authDisabled', !!authDisabled);
   }
 
   const { port = 0, host, backlog } = options;


### PR DESCRIPTION
## Summary

Adds an `authDisabled` server config flag to support anonymous sign-in for trusted local-network setups. I run mine on an RPi with touchscreen that auto-opens cncjs in the browser on boot. I like having both the touchscreen UI and having cncjs accessible over the home network. I don't want to have to type a password on this sort of setup.

When `authDisabled=true`, `/api/signin` now returns a signed synthetic `anonymous` identity, and server-side user validation no longer requires a configured user account. This keeps the existing token-based client boot flow intact while allowing auth to be disabled explicitly via config.

## Changes

- Added `authDisabled: false` to server defaults in [`src/server/config/settings.base.js`](./src/server/config/settings.base.js)
- Loaded `authDisabled` from `.cncrc` during server startup in [`src/server/index.js`](./src/server/index.js)
- Added a loud startup warning when `authDisabled` and `allowRemoteAccess` are both enabled in [`src/server/index.js`](./src/server/index.js)
- Updated [`src/server/api/api.users.js`](./src/server/api/api.users.js) so `POST /api/signin` returns an anonymous token when auth is disabled
- Updated [`src/server/access-control.js`](./src/server/access-control.js) so user validation is bypassed when auth is disabled
- Documented the new config flag and its intended usage in [`README.md`](./README.md)

## Tests

Added coverage in [`src/server/api/__tests__/api.users.test.js`](./src/server/api/__tests__/api.users.test.js) for the binary auth-disabled signin behavior:

- allows `/api/signin` to return an anonymous token when `authDisabled=true`
- rejects tokenless protected routes when `authDisabled=false`

