### PR TITLE
feat: make text labels crispier on hi-DPI screens

### DIFF
--- a/src/app/lib/pixel-ratio.js
+++ b/src/app/lib/pixel-ratio.js
@@ -1,0 +1,6 @@
+// Cap the device pixel ratio at 2x. Beyond that the extra texture/render
+// resolution costs GPU memory without a perceptible gain in crispness.
+const MAX_PIXEL_RATIO = 2;
+
+// Returns the device pixel ratio to render at, capped at MAX_PIXEL_RATIO.
+export const getRenderPixelRatio = () => Math.min(window.devicePixelRatio || 1, MAX_PIXEL_RATIO);

--- a/src/app/widgets/Visualizer/TextSprite.js
+++ b/src/app/widgets/Visualizer/TextSprite.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { getRenderPixelRatio } from 'app/lib/pixel-ratio';
 
 // TextSprite
 class TextSprite {
@@ -17,7 +18,10 @@ class TextSprite {
     const { opacity = 0.6, size = 10 } = options;
 
     const textObject = new THREE.Object3D();
-    const textHeight = 100;
+    // Bake the render pixel ratio into the texture resolution for crisp hi-DPI labels;
+    // sprite scale below divides by textHeight, so world size is unchanged.
+    const pixelRatio = getRenderPixelRatio();
+    const textHeight = 100 * pixelRatio;
     let textWidth = 0;
 
     const canvas = document.createElement('canvas');

--- a/src/app/widgets/Visualizer/Visualizer.jsx
+++ b/src/app/widgets/Visualizer/Visualizer.jsx
@@ -17,6 +17,7 @@ import CombinedCamera from 'app/lib/three/CombinedCamera';
 import TrackballControls from 'app/lib/three/TrackballControls';
 import * as WebGL from 'app/lib/three/WebGL';
 import log from 'app/lib/log';
+import { getRenderPixelRatio } from 'app/lib/pixel-ratio';
 import { mapValueToUnits } from 'app/lib/units';
 import store from 'app/store';
 import { getBoundingBox, loadSTL, loadTexture } from './helpers';
@@ -627,7 +628,7 @@ class Visualizer extends Component {
 
       this.controls.handleResize();
 
-      this.renderer.setPixelRatio(window.devicePixelRatio || 1);
+      this.renderer.setPixelRatio(getRenderPixelRatio());
       this.renderer.setSize(width, height);
 
       // Update the scene
@@ -868,7 +869,7 @@ class Visualizer extends Component {
       this.renderer.shadowMap.enabled = true;
       this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
       this.renderer.setClearColor(new THREE.Color(colornames('white')), 1);
-      this.renderer.setPixelRatio(window.devicePixelRatio || 1);
+      this.renderer.setPixelRatio(getRenderPixelRatio());
       this.renderer.setSize(width, height);
       this.renderer.clear();
 


### PR DESCRIPTION
Make text labels crispier on hi-DPI screens, trivial change, previously I have added general hi-DPI support but it did not touch labels, this is small fix to make labels crispier as well.

Tested on macbook pro m1 and text with the fix crispier (not ideally vector-level crisp but less blurred), open to migrate to vector-based but this would be a much heavier change.

**Follow up on https://github.com/cncjs/cncjs/pull/989, sorry, switched main branch, so GitHub forces new PR, same trivial change but encapsulated**

BEFORE:

<img width="831" height="714" alt="Screenshot 2026-06-28 at 16 01 03" src="https://github.com/user-attachments/assets/ea5b7f16-76af-48b3-8b74-cc6e062c1cbd" />

AFTER:

<img width="881" height="796" alt="Screenshot 2026-06-28 at 16 04 40" src="https://github.com/user-attachments/assets/595429d0-e872-41fe-ae33-0f05a55ce694" />
