### PR TITLE
feat: preserves partially typed Console commands while serial, jog, and macro output is rendered

### DIFF
--- a/.changeset/cncjs-pr-994.md
+++ b/.changeset/cncjs-pr-994.md
@@ -1,0 +1,5 @@
+---
+"cncjs": patch
+---
+
+feat: preserves partially typed Console commands while serial, jog, and macro output is rendered

--- a/src/app/widgets/Console/Terminal.jsx
+++ b/src/app/widgets/Console/Terminal.jsx
@@ -364,10 +364,22 @@ class TerminalWrapper extends PureComponent {
     }
 
     writeln(data) {
-      this.term.eraseRight(0, this.term.buffer.y);
-      this.term.write('\r');
-      this.term.write(data);
-      this.term.prompt();
+      const line = this.term.buffer.lines.get(this.term.buffer.ybase + this.term.buffer.y);
+      const cursorX = this.term.buffer.x;
+      let input = '';
+
+      if (line) {
+        for (let x = this.prompt.length; x < line.length; ++x) {
+          input += line[x][1] || '';
+        }
+        input = trimEnd(input);
+      }
+
+      const cursorOffset = Math.min(Math.max(0, cursorX - this.prompt.length), input.length);
+      const cursorLeft = input.length - cursorOffset;
+      const restoreCursor = cursorLeft > 0 ? `\x1b[${cursorLeft}D` : '';
+
+      this.term.write(`\x1b[2K\r${data}\r\n${chalk.white(this.prompt + input)}${restoreCursor}`);
     }
 
     render() {


### PR DESCRIPTION
## Summary

Preserves partially typed Console commands while serial, jog, and macro output is rendered.

## Root cause

Console output cleared the active terminal row. The initial redraw attempt also included xterm's unused blank cells and raced its asynchronous write queue, so repeated output could hide the restored input.

## Fix

Queue the clear, output, prompt, input redraw, and cursor restoration as one terminal write. Only redraw meaningful input characters.

Fixes #993

## Validation

- Replayed three consecutive macro outputs with xterm while editing a command mid-line
- `yarn eslint` (existing warnings only)
- `yarn build-prod`