### PR TITLE
Add probe-length compensation to tool-change offset math

### DIFF
--- a/src/app/widgets/Tool/Tool.jsx
+++ b/src/app/widgets/Tool/Tool.jsx
@@ -36,7 +36,7 @@ const TOOL_PROBE_OVERRIDE_WCS_EXAMPLE = `
 ; Probe the tool
 G91 [tool_probe_command] F[tool_probe_feedrate] Z[tool_probe_z - mposz - tool_probe_distance]
 ; Set coordinate system offset
-G10 L20 P[mapWCSToPValue(modal.wcs)] Z[touch_plate_height]
+G10 L20 P[mapWCSToPValue(modal.wcs)] Z[touch_plate_height + tool_probe_length]
 `.trim();
 
 const TOOL_PROBE_OVERRIDE_TLO_EXAMPLE = `
@@ -45,7 +45,7 @@ G91 [tool_probe_command] F[tool_probe_feedrate] Z[tool_probe_z - mposz - tool_pr
 ; Pause for 1 second
 %wait 1
 ; Set tool length offset
-G43.1 Z[posz - touch_plate_height]
+G43.1 Z[posz - touch_plate_height - tool_probe_length]
 `.trim();
 
 const copyToClipboard = value => {
@@ -184,6 +184,7 @@ class Tool extends PureComponent {
     const toolProbeCommand = get(toolConfig, 'toolProbeCommand');
     const toolProbeDistance = get(toolConfig, 'toolProbeDistance');
     const toolProbeFeedrate = get(toolConfig, 'toolProbeFeedrate');
+    const toolProbeLength = get(toolConfig, 'toolProbeLength');
     const touchPlateHeight = get(toolConfig, 'touchPlateHeight');
     const isManualToolChange = [
       TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_WCS,
@@ -203,13 +204,13 @@ class Tool extends PureComponent {
         lines.push('; Probe the tool');
         lines.push('G91 [tool_probe_command] F[tool_probe_feedrate] Z[tool_probe_z - posz - tool_probe_distance]');
         if (toolChangePolicy === TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_WCS) {
-          lines.push('; Set the current work Z position (posz) to the touch plate height');
-          lines.push('G92 Z[touch_plate_height]');
+          lines.push('; Set the current work Z position (posz) to the touch plate height plus the probe length');
+          lines.push('G92 Z[touch_plate_height + tool_probe_length]');
         } else if (toolChangePolicy === TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_TLO) {
           lines.push('; Pause for 1 second');
           lines.push('%wait 1');
-          lines.push('; Adjust the work Z position by subtracting the touch plate height from the current work Z position (posz)');
-          lines.push('G92 Z[posz - touch_plate_height]');
+          lines.push('; Adjust the work Z position by subtracting the touch plate height and probe length from the current work Z position (posz)');
+          lines.push('G92 Z[posz - touch_plate_height - tool_probe_length]');
         }
         return lines.join('\n');
       }
@@ -219,12 +220,12 @@ class Tool extends PureComponent {
         lines.push('G91 [tool_probe_command] F[tool_probe_feedrate] Z[tool_probe_z - mposz - tool_probe_distance]');
         if (toolChangePolicy === TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_WCS) {
           lines.push('; Set coordinate system offset');
-          lines.push('G10 L20 P[mapWCSToPValue(modal.wcs)] Z[touch_plate_height]');
+          lines.push('G10 L20 P[mapWCSToPValue(modal.wcs)] Z[touch_plate_height + tool_probe_length]');
         } else if (toolChangePolicy === TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_TLO) {
           lines.push('; Pause for 1 second');
           lines.push('%wait 1');
           lines.push('; Set tool length offset');
-          lines.push('G43.1 Z[posz - touch_plate_height]');
+          lines.push('G43.1 Z[posz - touch_plate_height - tool_probe_length]');
         }
         return lines.join('\n');
       }
@@ -234,12 +235,12 @@ class Tool extends PureComponent {
         lines.push('G91 [tool_probe_command] F[tool_probe_feedrate] Z[tool_probe_z - mposz - tool_probe_distance]');
         if (toolChangePolicy === TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_WCS) {
           lines.push('; Set coordinate system offset');
-          lines.push('G10 L20 P[mapWCSToPValue(modal.wcs)] Z[touch_plate_height]');
+          lines.push('G10 L20 P[mapWCSToPValue(modal.wcs)] Z[touch_plate_height + tool_probe_length]');
         } else if (toolChangePolicy === TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_TLO) {
           lines.push('; Pause for 1 second');
           lines.push('%wait 1');
           lines.push('; Set tool length offset');
-          lines.push('{tofz:[posz - touch_plate_height]}');
+          lines.push('{tofz:[posz - touch_plate_height - tool_probe_length]}');
         }
         return lines.join('\n');
       }
@@ -776,7 +777,29 @@ class Tool extends PureComponent {
                       </div>
                     </div>
                   </div>
+                  <div className="col-xs-6" style={{ paddingLeft: 5 }}>
+                    <div className="form-group">
+                      <label className="control-label">{i18n._('Probe Length')}</label>
+                      <div className="input-group input-group-sm">
+                        <input
+                          type="number"
+                          className="form-control"
+                          value={toolProbeLength}
+                          min={0}
+                          step={step}
+                          onChange={(event) => {
+                            const value = event.target.value;
+                            actions.setToolProbeLength(value);
+                          }}
+                        />
+                        <span className="input-group-addon">{displayUnits}</span>
+                      </div>
+                    </div>
+                  </div>
                 </div>
+                <p style={{ marginTop: -4, marginBottom: 12 }}>
+                  <i>{i18n._('Probe Length is how far the touch probe\'s contact point sits below the tool tip. It is added to Touch Plate Height when computing the Z offset.')}</i>
+                </p>
                 <div>
                   <div
                     style={{

--- a/src/app/widgets/Tool/index.jsx
+++ b/src/app/widgets/Tool/index.jsx
@@ -166,6 +166,14 @@ class ToolWidget extends PureComponent {
         },
       });
     },
+    setToolProbeLength: (value) => {
+      this.setState({
+        toolConfig: {
+          ...this.state.toolConfig,
+          toolProbeLength: value,
+        },
+      });
+    },
   };
 
   controllerEvents = {
@@ -313,6 +321,7 @@ class ToolWidget extends PureComponent {
           toolProbeX: mapPositionToUnits(this.toolConfig.get('toolProbeX'), units),
           toolProbeY: mapPositionToUnits(this.toolConfig.get('toolProbeY'), units),
           toolProbeZ: mapPositionToUnits(this.toolConfig.get('toolProbeZ'), units),
+          toolProbeLength: mapValueToUnits(this.toolConfig.get('toolProbeLength'), units),
           touchPlateHeight: mapValueToUnits(this.toolConfig.get('touchPlateHeight'), units),
         },
       });
@@ -339,6 +348,7 @@ class ToolWidget extends PureComponent {
       this.toolConfig.set('toolProbeCommand', ensureString(get(tool, 'toolProbeCommand', 'G38.2')));
       this.toolConfig.set('toolProbeDistance', ensureNumber(get(tool, 'toolProbeDistance', 1)));
       this.toolConfig.set('toolProbeFeedrate', ensureNumber(get(tool, 'toolProbeFeedrate', 10)));
+      this.toolConfig.set('toolProbeLength', ensureNumber(get(tool, 'toolProbeLength', 0)));
       this.toolConfig.set('touchPlateHeight', ensureNumber(get(tool, 'touchPlateHeight', 0)));
 
       // The state reflects the values in the current display units
@@ -355,6 +365,7 @@ class ToolWidget extends PureComponent {
           toolProbeCommand: this.toolConfig.get('toolProbeCommand'),
           toolProbeDistance: mapValueToUnits(this.toolConfig.get('toolProbeDistance'), units),
           toolProbeFeedrate: mapValueToUnits(this.toolConfig.get('toolProbeFeedrate'), units),
+          toolProbeLength: mapValueToUnits(this.toolConfig.get('toolProbeLength'), units),
           touchPlateHeight: mapValueToUnits(this.toolConfig.get('touchPlateHeight'), units),
         },
       });
@@ -418,6 +429,7 @@ class ToolWidget extends PureComponent {
       toolProbeX,
       toolProbeY,
       toolProbeZ,
+      toolProbeLength,
       touchPlateHeight,
     } = this.state.toolConfig;
 
@@ -433,6 +445,7 @@ class ToolWidget extends PureComponent {
     this.toolConfig.set('toolProbeCommand', ensureString(toolProbeCommand));
     this.toolConfig.set('toolProbeDistance', toMetric(toolProbeDistance));
     this.toolConfig.set('toolProbeFeedrate', toMetric(toolProbeFeedrate));
+    this.toolConfig.set('toolProbeLength', toMetric(toolProbeLength));
     this.toolConfig.set('touchPlateHeight', toMetric(touchPlateHeight));
   }
 

--- a/src/server/api/api.tool.js
+++ b/src/server/api/api.tool.js
@@ -26,6 +26,7 @@ export const set = (req, res) => {
     'toolProbeCommand',
     'toolProbeDistance',
     'toolProbeFeedrate',
+    'toolProbeLength',
     'touchPlateHeight',
   ]);
   const invalidKeys = keys.filter((key) => !allowedKeySet.has(key));

--- a/src/server/controllers/Grbl/GrblController.js
+++ b/src/server/controllers/Grbl/GrblController.js
@@ -1670,6 +1670,7 @@ class GrblController {
           const toolProbeCommand = config.get('tool.toolProbeCommand', 'G38.2');
           const toolProbeDistance = mapValueToUnits(config.get('tool.toolProbeDistance', 1), units);
           const toolProbeFeedrate = mapValueToUnits(config.get('tool.toolProbeFeedrate', 10), units);
+          const toolProbeLength = mapValueToUnits(config.get('tool.toolProbeLength', 0), units);
           const touchPlateHeight = mapValueToUnits(config.get('tool.touchPlateHeight', 0), units);
 
           const context = {
@@ -1682,6 +1683,7 @@ class GrblController {
             'tool_probe_command': toolProbeCommand,
             'tool_probe_distance': toolProbeDistance,
             'tool_probe_feedrate': toolProbeFeedrate,
+            'tool_probe_length': toolProbeLength,
             'touch_plate_height': touchPlateHeight,
 
             // internal functions
@@ -1732,14 +1734,14 @@ class GrblController {
             // Probe the tool
             lines.push('G91 [tool_probe_command] F[tool_probe_feedrate] Z[tool_probe_z - mposz - tool_probe_distance]');
             // Set coordinate system offset
-            lines.push('G10 L20 P[mapWCSToPValue(modal.wcs)] Z[touch_plate_height]');
+            lines.push('G10 L20 P[mapWCSToPValue(modal.wcs)] Z[touch_plate_height + tool_probe_length]');
           } else if (toolChangePolicy === TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_TLO) {
             // Probe the tool
             lines.push('G91 [tool_probe_command] F[tool_probe_feedrate] Z[tool_probe_z - mposz - tool_probe_distance]');
             // Pause for 1 second
             lines.push('%wait 1');
             // Set tool length offset
-            lines.push('G43.1 Z[posz - touch_plate_height]');
+            lines.push('G43.1 Z[posz - touch_plate_height - tool_probe_length]');
           } else if (toolChangePolicy === TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_CUSTOM_PROBING) {
             lines.push(...toolProbeCustomCommands);
           }


### PR DESCRIPTION
## Summary
- Adds a `toolProbeLength` config field (global, alongside `touchPlateHeight`) representing the touch probe's stylus/stickout length below the tool tip
- Wires it into the Grbl WCS/TLO tool-change offset math (`G10 L20`/`G43.1`), and into the Tool widget's G-code preview for all four controller branches (GRBL/Smoothie/Marlin/TinyG)
- Adds a "Probe Length" input next to "Touch Plate Height" in the Tool widget UI

## Context
First step of a larger effort building a tool library, tool length offset support, and extended probing cycles on top of this fork's existing Probe/Autolevel/Tool widgets. This PR only covers the probe-length compensation piece; the tool library data model and probing-cycle extensions are still to come on this branch.

## Test plan
- [x] `eslint` passes clean on all changed files
- [x] `yarn dev` builds and serves cleanly under Node 22 (backend, webpack dev server, and the `serialport` native binding all verified running under genuine Node 22.23.2 via process inspection)
- [x] Confirmed via the served bundle that `toolProbeLength`/`tool_probe_length`/"Probe Length" ship correctly to the client
- [ ] Live dry-run on real grblHAL hardware to verify the offset sign/math before trusting it for an actual job (not yet done — no hardware connected during this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)