### PR TITLE
fix(autolevel): store probe measurements at the intended grid node's XY

### DIFF
--- a/.changeset/autolevel-grid-node-xy.md
+++ b/.changeset/autolevel-grid-node-xy.md
@@ -2,4 +2,6 @@
 "cncjs": patch
 ---
 
+fix(autolevel): store probe measurements at the intended grid node's XY
+
 Record every autolevel probe measurement at the intended grid node's XY instead of the machine-reported XY, which is quantised by the motor steps and splits grid lines into near-duplicates.

--- a/.changeset/autolevel-grid-node-xy.md
+++ b/.changeset/autolevel-grid-node-xy.md
@@ -1,0 +1,5 @@
+---
+"cncjs": patch
+---
+
+Record every autolevel probe measurement at the intended grid node's XY instead of the machine-reported XY, which is quantised by the motor steps and splits grid lines into near-duplicates.

--- a/src/server/controllers/Grbl/GrblController.js
+++ b/src/server/controllers/Grbl/GrblController.js
@@ -770,6 +770,20 @@ class GrblController {
               probedPos
             });
             if (this.probeState.probePoints.length > 0 && this.probeState.probedPositions.length < this.probeState.probePoints.length) {
+              // Record the measurement at the intended grid node's XY and keep only the
+              // measured Z. The reported XY is quantised by the motor steps (a commanded
+              // Y60 reads back as 59.999), and mixing quantised readings with exact node
+              // values splits one grid line into two 0.001 mm apart: the detected grid
+              // spacing collapses and the lattice fills with holes, so compensation
+              // subdivides every move into thousands of segments over a broken surface.
+              //
+              // Probe points carry the units the probe G-code was emitted in, which is
+              // the modal state -- $13 governs the PRB report only.
+              const isImperial = this.runner.getModalGroup().units === 'G20';
+              const gridNode = this.probeState.probePoints[this.probeState.probedPositions.length];
+              probedPos.x = isImperial ? in2mm(gridNode.x) : gridNode.x;
+              probedPos.y = isImperial ? in2mm(gridNode.y) : gridNode.y;
+
               const newProbedPositions = [...this.probeState.probedPositions, probedPos];
               const isCompleted = newProbedPositions.length >= this.probeState.probePoints.length;
 

--- a/src/server/controllers/Grbl/__tests__/GrblController.test.js
+++ b/src/server/controllers/Grbl/__tests__/GrblController.test.js
@@ -751,6 +751,34 @@ describe('GrblController', () => {
       expect(controller.probeState.config).toEqual(params);
     });
 
+    test('the probe measurement is stored at the intended grid node with the measured Z', () => {
+      const { controller } = setup();
+      controller.probeState.probePoints = [{ x: 0, y: 0 }, { x: 10, y: 0 }];
+      controller.runner.state.status = {
+        mpos: { x: '0.000', y: '0.000', z: '0.000' },
+        wpos: { x: '0.000', y: '0.000', z: '0.000' },
+      };
+
+      // Quantised reports: the commanded nodes (0,0) and (10,0) read back off-node.
+      controller.runner.emit('parameters', {
+        raw: '[PRB:0.001,0.001,-1.500:1]',
+        name: 'PRB',
+        value: { result: 1, x: '0.001', y: '0.001', z: '-1.500' },
+      });
+      controller.runner.emit('parameters', {
+        raw: '[PRB:10.001,-0.001,-1.000:1]',
+        name: 'PRB',
+        value: { result: 1, x: '10.001', y: '-0.001', z: '-1.000' },
+      });
+
+      expect(controller.probeState.probedPositions).toEqual([
+        { x: 0, y: 0, z: -1.5 },
+        { x: 10, y: 0, z: -1 },
+      ]);
+      expect(controller.probeState.minZ).toBe(-1.5);
+      expect(controller.probeState.maxZ).toBe(-1);
+    });
+
     test('autolevel:stop resets the controller and clears the probe state', () => {
       const { controller, writes } = setup();
 

--- a/src/server/controllers/Marlin/MarlinController.js
+++ b/src/server/controllers/Marlin/MarlinController.js
@@ -807,6 +807,19 @@ class MarlinController {
           log.debug('[autolevel] Probe position captured:', { probedPos });
 
           if (this.probeState.probePoints.length > 0 && this.probeState.probedPositions.length < this.probeState.probePoints.length) {
+            // Record the measurement at the intended grid node's XY and keep only the
+            // measured Z. The reported XY is quantised by the motor steps (a commanded
+            // Y60 reads back as 59.999), and mixing quantised readings with exact node
+            // values splits one grid line into two 0.001 mm apart: the detected grid
+            // spacing collapses and the lattice fills with holes, so compensation
+            // subdivides every move into thousands of segments over a broken surface.
+            //
+            // Probe points carry the units the probe G-code was emitted in; probe
+            // data is stored in mm.
+            const gridNode = this.probeState.probePoints[this.probeState.probedPositions.length];
+            probedPos.x = isImperial ? in2mm(gridNode.x) : gridNode.x;
+            probedPos.y = isImperial ? in2mm(gridNode.y) : gridNode.y;
+
             const newProbedPositions = [...this.probeState.probedPositions, probedPos];
             const isCompleted = newProbedPositions.length >= this.probeState.probePoints.length;
 

--- a/src/server/controllers/Marlin/__tests__/MarlinController.test.js
+++ b/src/server/controllers/Marlin/__tests__/MarlinController.test.js
@@ -684,18 +684,28 @@ describe('MarlinController', () => {
       expect(controller.history.writeLine).toBe('');
     });
 
-    test('the position report after a probe is captured into the probe state', () => {
+    test('the probe measurement is stored at the intended grid node with the measured Z', () => {
       setup();
       controller.probeState.probePoints = [{ x: 0, y: 0 }, { x: 10, y: 0 }];
+
+      // Quantised reports: the commanded nodes (0,0) and (10,0) read back off-node.
+      controller.runner.state.pos = { x: '0.001', y: '0.001', z: '-1.500' };
       controller.history.writeLine = 'G38.2 Z-1';
       controller.runner.emit('ok', { raw: 'ok' });
+      controller.runner.emit('pos', { raw: 'X:0.001 Y:0.001 Z:-1.500 E:0.000' });
 
-      controller.runner.state.pos = { x: '1.000', y: '2.000', z: '3.000' };
-      controller.runner.emit('pos', { raw: 'X:1.000 Y:2.000 Z:3.000 E:0.000' });
+      controller.runner.state.pos = { x: '10.001', y: '-0.001', z: '-1.000' };
+      controller.history.writeLine = 'G38.2 Z-1';
+      controller.runner.emit('ok', { raw: 'ok' });
+      controller.runner.emit('pos', { raw: 'X:10.001 Y:-0.001 Z:-1.000 E:0.000' });
+
       expect(controller.probeState.pendingProbeCapture).toBe(false);
-      expect(controller.probeState.probedPositions).toEqual([{ x: 1, y: 2, z: 3 }]);
-      expect(controller.probeState.minZ).toBe(3);
-      expect(controller.probeState.maxZ).toBe(3);
+      expect(controller.probeState.probedPositions).toEqual([
+        { x: 0, y: 0, z: -1.5 },
+        { x: 10, y: 0, z: -1 },
+      ]);
+      expect(controller.probeState.minZ).toBe(-1.5);
+      expect(controller.probeState.maxZ).toBe(-1);
     });
   });
 });

--- a/src/server/controllers/Smoothie/SmoothieController.js
+++ b/src/server/controllers/Smoothie/SmoothieController.js
@@ -725,6 +725,19 @@ class SmoothieController {
               probedPos
             });
             if (this.probeState.probePoints.length > 0 && this.probeState.probedPositions.length < this.probeState.probePoints.length) {
+              // Record the measurement at the intended grid node's XY and keep only the
+              // measured Z. The reported XY is quantised by the motor steps (a commanded
+              // Y60 reads back as 59.999), and mixing quantised readings with exact node
+              // values splits one grid line into two 0.001 mm apart: the detected grid
+              // spacing collapses and the lattice fills with holes, so compensation
+              // subdivides every move into thousands of segments over a broken surface.
+              //
+              // Probe points carry the units the probe G-code was emitted in; probe
+              // data is stored in mm.
+              const gridNode = this.probeState.probePoints[this.probeState.probedPositions.length];
+              probedPos.x = isImperial ? in2mm(gridNode.x) : gridNode.x;
+              probedPos.y = isImperial ? in2mm(gridNode.y) : gridNode.y;
+
               const newProbedPositions = [...this.probeState.probedPositions, probedPos];
               const isCompleted = newProbedPositions.length >= this.probeState.probePoints.length;
 

--- a/src/server/controllers/Smoothie/__tests__/SmoothieController.test.js
+++ b/src/server/controllers/Smoothie/__tests__/SmoothieController.test.js
@@ -707,6 +707,34 @@ describe('SmoothieController', () => {
       expect(controller.probeState.maxZ).toBeNull();
     });
 
+    test('the probe measurement is stored at the intended grid node with the measured Z', () => {
+      const { controller } = create();
+      controller.probeState.probePoints = [{ x: 0, y: 0 }, { x: 10, y: 0 }];
+      controller.runner.state.status = {
+        mpos: { x: '0.000', y: '0.000', z: '0.000' },
+        wpos: { x: '0.000', y: '0.000', z: '0.000' },
+      };
+
+      // Quantised reports: the commanded nodes (0,0) and (10,0) read back off-node.
+      controller.runner.emit('parameters', {
+        raw: '[PRB:0.001,0.001,-1.500:1]',
+        name: 'PRB',
+        value: { result: 1, x: '0.001', y: '0.001', z: '-1.500' },
+      });
+      controller.runner.emit('parameters', {
+        raw: '[PRB:10.001,-0.001,-1.000:1]',
+        name: 'PRB',
+        value: { result: 1, x: '10.001', y: '-0.001', z: '-1.000' },
+      });
+
+      expect(controller.probeState.probedPositions).toEqual([
+        { x: 0, y: 0, z: -1.5 },
+        { x: 10, y: 0, z: -1 },
+      ]);
+      expect(controller.probeState.minZ).toBe(-1.5);
+      expect(controller.probeState.maxZ).toBe(-1);
+    });
+
     test('autolevel:stop resets the connection and clears probe state', () => {
       const { controller, writes } = create();
       controller.probeState = {

--- a/src/server/controllers/TinyG/TinyGController.js
+++ b/src/server/controllers/TinyG/TinyGController.js
@@ -646,6 +646,19 @@ class TinyGController {
             probedPos
           });
           if (this.probeState.probePoints.length > 0 && this.probeState.probedPositions.length < this.probeState.probePoints.length) {
+            // Record the measurement at the intended grid node's XY and keep only the
+            // measured Z. The reported XY is quantised by the motor steps (a commanded
+            // Y60 reads back as 59.999), and mixing quantised readings with exact node
+            // values splits one grid line into two 0.001 mm apart: the detected grid
+            // spacing collapses and the lattice fills with holes, so compensation
+            // subdivides every move into thousands of segments over a broken surface.
+            //
+            // Probe points carry the units the probe G-code was emitted in; probe
+            // data is stored in mm.
+            const gridNode = this.probeState.probePoints[this.probeState.probedPositions.length];
+            probedPos.x = isImperial ? in2mm(gridNode.x) : gridNode.x;
+            probedPos.y = isImperial ? in2mm(gridNode.y) : gridNode.y;
+
             const newProbedPositions = [...this.probeState.probedPositions, probedPos];
             const isCompleted = newProbedPositions.length >= this.probeState.probePoints.length;
 

--- a/src/server/controllers/TinyG/__tests__/TinyGController.test.js
+++ b/src/server/controllers/TinyG/__tests__/TinyGController.test.js
@@ -753,6 +753,26 @@ describe('TinyGController', () => {
       });
     });
 
+    test('the probe measurement is stored at the intended grid node with the measured Z', () => {
+      const { controller } = setupController();
+      controller.probeState.probePoints = [{ x: 0, y: 0 }, { x: 10, y: 0 }];
+      controller.runner.state.sr = {
+        mpos: { x: 0.000, y: 0.000, z: 0.000 },
+        wpos: { x: 0.000, y: 0.000, z: 0.000 },
+      };
+
+      // Quantised reports: the commanded nodes (0,0) and (10,0) read back off-node.
+      controller.runner.emit('r', { prb: { e: 1, x: 0.001, y: 0.001, z: -1.5 } });
+      controller.runner.emit('r', { prb: { e: 1, x: 10.001, y: -0.001, z: -1 } });
+
+      expect(controller.probeState.probedPositions).toEqual([
+        { x: 0, y: 0, z: -1.5 },
+        { x: 10, y: 0, z: -1 },
+      ]);
+      expect(controller.probeState.minZ).toBe(-1.5);
+      expect(controller.probeState.maxZ).toBe(-1);
+    });
+
     test('autolevel:stop resets the board and clears the probe state', () => {
       const { controller, writes } = setupController();
 

--- a/src/server/lib/__tests__/autolevel.test.js
+++ b/src/server/lib/__tests__/autolevel.test.js
@@ -364,5 +364,57 @@ describe('autolevel', () => {
         expect(result).toBe('G0 X4.000 Y4.000 Z0.400');
       });
     });
+
+    // A machine reports a probed XY quantised by its motor steps: the same
+    // commanded Y comes back as 10.000 at one node and 9.999 at the next.
+    //
+    // These characterise the compensation's sensitivity to that input -- they
+    // are the reason the controllers now record the intended grid node's XY,
+    // not a regression test for the controllers themselves, which have no test
+    // harness in this repo. Hardening the library against degenerate spacing
+    // would be a fix, not a regression, and would change what they assert.
+    describe('quantised probe XY', () => {
+      const saddleZ = (x, y) => (x / 10) * (y / 10); // bilinear and plane fit disagree here
+      const exactGrid = [];
+      for (const y of [0, 10, 20]) {
+        for (const x of [0, 10, 20]) {
+          exactGrid.push({ x, y, z: saddleZ(x, y) });
+        }
+      }
+      // The middle row splits in two: its outer nodes read 0.001mm short of Y10.
+      const quantisedGrid = exactGrid.map(p => (
+        (p.y === 10 && p.x !== 10) ? { ...p, y: 9.999 } : p
+      ));
+
+      test('collapses the detected grid spacing, exploding the output', () => {
+        const gcode = 'G0 X0 Y5 Z0\nG0 X20 Y5 Z0';
+        const exact = applyProbeCompensation(gcode, exactGrid).split('\n');
+        const quantised = applyProbeCompensation(gcode, quantisedGrid).split('\n');
+
+        // 10mm grid -> 5mm segments -> the 20mm move splits into 4.
+        expect(exact).toHaveLength(5);
+
+        // The split row leaves a Y gap of 0.001mm, which becomes the detected
+        // step, and the move is subdivided three orders of magnitude finer.
+        // The exact count follows the library's segmentation rule, so assert
+        // the collapse rather than the number it happens to produce today.
+        expect(quantised.length).toBeGreaterThan(exact.length * 1000);
+      });
+
+      test('punches holes in the lattice, falling back to the plane fit', () => {
+        const gcode = 'G0 X5 Y5 Z0';
+
+        // Bilinear over an intact cell: the four-corner average.
+        expect(applyProbeCompensation(gcode, exactGrid)).toBe('G0 X5.000 Y5.000 Z0.250');
+
+        // Neither of the two near-duplicate rows is complete, so no cell has
+        // all four corners, and the plane fit through Y0 and the Y9.999 nodes
+        // reports the surface as flat. What matters is that the compensation
+        // is gone, not the exact figure the fallback degrades to.
+        const degraded = applyProbeCompensation(gcode, quantisedGrid);
+        const degradedZ = Number(/Z(-?[\d.]+)/.exec(degraded)[1]);
+        expect(Math.abs(degradedZ)).toBeLessThan(0.05);
+      });
+    });
   });
 });


### PR DESCRIPTION
## The bug

All four controllers record the position the machine reported back with the probe result:

```js
const newProbedPositions = [...this.probeState.probedPositions, probedPos];
```

`probedPos` is built from the machine's own position report — `PRB:` for Grbl and Smoothie, `prb` for TinyG, the `M114` reply for Marlin. Its XY is quantised: a commanded `Y60` reads back as `59.999`, and the same commanded coordinate does not round the same way on every visit.

Compensation detects the probe grid from the probed data itself (`buildProbeGrid` in `src/server/lib/autolevel.js`, 1 µm tolerance). Once one grid line has been recorded both as `60` and as `59.999`, it is two grid lines 0.001 mm apart, and two things follow:

1. `minSpacing` returns 0.001 mm, so the detected step collapses. `applyProbeCompensation` subdivides every move at `step / 2` — 0.0005 mm. A 20 mm move becomes 40 000 output lines.
2. Neither of the two near-duplicate lines is complete, so the lattice is full of holes. `bilinearZ` returns `null` for those cells and every point falls through to the 3-point plane fit — the slow path, over a surface that no longer describes the workpiece.

The server log shows the collapse in plain sight:

```
Applying Z compensation (auto-detected grid: 10.00mm × 0.00mm, 9 points)...
```

## The fix

Z is the only thing the probe discovered. The XY is the node the machine was *told* to go to, and it was known before probing started. Each controller now overwrites the reported XY with the intended node before pushing the measurement:

```js
const gridNode = this.probeState.probePoints[this.probeState.probedPositions.length];
probedPos.x = isImperial ? in2mm(gridNode.x) : gridNode.x;
probedPos.y = isImperial ? in2mm(gridNode.y) : gridNode.y;
```

The guard right above it (`probedPositions.length < probePoints.length`) already makes the index valid, so no extra checking is needed. Overwriting in place keeps the stored position, the `autolevel:update` payload the widget accumulates into its own copy, and the per-point progress log all carrying the exact node. Each controller's existing debug line runs before the overwrite and still shows the raw reported position, which is where the quantisation stays visible. (The line is named `Checking probe state` in Grbl, Smoothie and TinyG, and `Probe position captured` in Marlin.)

**Units.** Probe points carry the units the probe G-code was emitted in (the widget sends `startX`/`stepX`/… in the current display units and the server interpolates them straight into `G0 X… Y…`), while probe data is stored in mm. So the node XY is converted under `G20`. Marlin, Smoothie and TinyG reuse the `isImperial` they already derive from the modal state a few lines up. Grbl reads the modal state separately, because its existing `reportInches` flag comes from `$13`, which governs the `PRB` report only and is independent of `G20`/`G21`.

## Scope

All four controllers had the same defect; all four are fixed.

| Controller | Where the recorded XY came from |
| --- | --- |
| Grbl | `PRB:` report minus WCO |
| Smoothie | `PRB:` report minus WCO |
| TinyG | `prb` report minus WCO |
| Marlin | `M114` work position captured after the probe |

Marlin differs slightly in kind: `M114` reports the logical position, which stock firmware formats to two decimals (`X:0.00`). The loss is coarser than stepper quantisation but the failure is identical — a value the machine reports rather than the value it was commanded, which is enough to split a grid line.

## Tests

The fix lives in the controllers, but the damage lives in `src/server/lib/autolevel.js`, so the tests go there. Two new cases feed `applyProbeCompensation` a 3×3 grid whose middle row is split between `Y10` and `Y9.999` — exactly what a quantised report produces — and compare it against the same grid with exact node values:

| | exact grid | split grid |
| --- | --- | --- |
| output lines for `G0 X0 Y5` → `G0 X20 Y5` | 5 | over 1000x more |
| compensation at (5, 5) on a saddle surface | `Z0.250` | essentially zero |

The exact figures today are 40 001 lines and `Z0.000`, but the tests assert the
collapse rather than those numbers: hardening `minSpacing` against degenerate
spacing would be a fix, not a regression, and should not have to fight a test.

The second row is the one that cuts: with the grid intact, bilinear interpolation returns the four-corner average; with it split, no cell has all four corners, the plane fit runs through `Y0` and the `Y9.999` nodes, and it reports the surface as flat — 0.25 mm of compensation silently lost.

Both describe today's `autolevel.js` behaviour and are unchanged by this PR. They characterise the compensation's sensitivity to quantised input -- the reason the controllers must not feed it -- rather than guard the controller change itself, which has no test harness in this repo.

## Verification

- `npx eslint src/**/*.js src/app/**/*.jsx scripts/**/*.js` — 0 errors, 46 warnings, unchanged from master. The only warning in a touched file (`["$13"] is better written in dot notation`, GrblController.js:751) pre-exists and sits above the edit.
- `npx jest` — 11 suites, 240 tests passing.
- Not run on hardware. The failure mode and the numbers above come from the compensation code, not from a machine.

## One interaction worth flagging

The handler treats any `[PRB:...]` line as the result of the probe cycle in flight, but Grbl also
prints `[PRB:...]` in the `$#` parameter dump — which the UI itself sends from the Refresh button in
**Grbl → Controller Settings**. Pressing it mid-run was already corrupting the map before this
change (it appended a duplicate point carrying a stale Z); with the index-based lookup it now stamps
that stale Z onto the *next* node and shifts every node after it.

The window is narrow and the defect is pre-existing, so I have left it out of this PR rather than
widen a one-line fix. Happy to add a guard here instead if you would rather see them land together —
the natural one is to reject a `PRB` whose reported XY is further from the intended node than half a
grid step.
