### PR TITLE
feat(autolevel): add optional zigzag (serpentine) probe scan path

### DIFF
--- a/.changeset/autolevel-serpentine.md
+++ b/.changeset/autolevel-serpentine.md
@@ -1,0 +1,5 @@
+---
+"cncjs": patch
+---
+
+Add an optional zigzag (serpentine) autolevel scan path that probes odd rows right-to-left, dropping the return rapid at the start of every row.

--- a/src/app/i18n/cs/resource.json
+++ b/src/app/i18n/cs/resource.json
@@ -645,5 +645,7 @@
   "Clearance Z: {{value}} {{- units}}": "Výška přejezdu Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Počáteční Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Koncové Z: {{value}} {{- units}}",
-  "None": "Žádný"
+  "None": "Žádný",
+  "Zigzag scan path": "",
+  "Probe odd rows right-to-left (serpentine) so the head continues from where the previous row ended, without the rapid back to the start of X at every row. Same points, same grid.": ""
 }

--- a/src/app/i18n/de/resource.json
+++ b/src/app/i18n/de/resource.json
@@ -643,5 +643,7 @@
   "Clearance Z: {{value}} {{- units}}": "Freifahrhöhe Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Start-Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "End-Z: {{value}} {{- units}}",
-  "None": "Keine"
+  "None": "Keine",
+  "Zigzag scan path": "",
+  "Probe odd rows right-to-left (serpentine) so the head continues from where the previous row ended, without the rapid back to the start of X at every row. Same points, same grid.": ""
 }

--- a/src/app/i18n/en/resource.json
+++ b/src/app/i18n/en/resource.json
@@ -643,5 +643,7 @@
   "Clearance Z: {{value}} {{- units}}": "Clearance Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Start Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "End Z: {{value}} {{- units}}",
-  "None": "None"
+  "None": "None",
+  "Zigzag scan path": "Zigzag scan path",
+  "Probe odd rows right-to-left (serpentine) so the head continues from where the previous row ended, without the rapid back to the start of X at every row. Same points, same grid.": "Probe odd rows right-to-left (serpentine) so the head continues from where the previous row ended, without the rapid back to the start of X at every row. Same points, same grid."
 }

--- a/src/app/i18n/es/resource.json
+++ b/src/app/i18n/es/resource.json
@@ -644,5 +644,7 @@
   "Clearance Z: {{value}} {{- units}}": "Z de separación: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Z inicial: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Z final: {{value}} {{- units}}",
-  "None": "Ninguno"
+  "None": "Ninguno",
+  "Zigzag scan path": "",
+  "Probe odd rows right-to-left (serpentine) so the head continues from where the previous row ended, without the rapid back to the start of X at every row. Same points, same grid.": ""
 }

--- a/src/app/i18n/fr/resource.json
+++ b/src/app/i18n/fr/resource.json
@@ -644,5 +644,7 @@
   "Clearance Z: {{value}} {{- units}}": "Z de dégagement : {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Z de départ : {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Z de fin : {{value}} {{- units}}",
-  "None": "Aucun"
+  "None": "Aucun",
+  "Zigzag scan path": "",
+  "Probe odd rows right-to-left (serpentine) so the head continues from where the previous row ended, without the rapid back to the start of X at every row. Same points, same grid.": ""
 }

--- a/src/app/i18n/hu/resource.json
+++ b/src/app/i18n/hu/resource.json
@@ -643,5 +643,7 @@
   "Clearance Z: {{value}} {{- units}}": "Z biztonsági magasság: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Kezdeti Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Végső Z: {{value}} {{- units}}",
-  "None": "Nincs"
+  "None": "Nincs",
+  "Zigzag scan path": "",
+  "Probe odd rows right-to-left (serpentine) so the head continues from where the previous row ended, without the rapid back to the start of X at every row. Same points, same grid.": ""
 }

--- a/src/app/i18n/it/resource.json
+++ b/src/app/i18n/it/resource.json
@@ -644,5 +644,7 @@
   "Clearance Z: {{value}} {{- units}}": "Z di sicurezza: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Z iniziale: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Z finale: {{value}} {{- units}}",
-  "None": "Nessuno"
+  "None": "Nessuno",
+  "Zigzag scan path": "",
+  "Probe odd rows right-to-left (serpentine) so the head continues from where the previous row ended, without the rapid back to the start of X at every row. Same points, same grid.": ""
 }

--- a/src/app/i18n/ja/resource.json
+++ b/src/app/i18n/ja/resource.json
@@ -642,5 +642,7 @@
   "Clearance Z: {{value}} {{- units}}": "クリアランスZ: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "開始Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "終了Z: {{value}} {{- units}}",
-  "None": "なし"
+  "None": "なし",
+  "Zigzag scan path": "",
+  "Probe odd rows right-to-left (serpentine) so the head continues from where the previous row ended, without the rapid back to the start of X at every row. Same points, same grid.": ""
 }

--- a/src/app/i18n/nb/resource.json
+++ b/src/app/i18n/nb/resource.json
@@ -643,5 +643,7 @@
   "Clearance Z: {{value}} {{- units}}": "Frihøyde Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Start-Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Slutt-Z: {{value}} {{- units}}",
-  "None": "Ingen"
+  "None": "Ingen",
+  "Zigzag scan path": "",
+  "Probe odd rows right-to-left (serpentine) so the head continues from where the previous row ended, without the rapid back to the start of X at every row. Same points, same grid.": ""
 }

--- a/src/app/i18n/nl/resource.json
+++ b/src/app/i18n/nl/resource.json
@@ -643,5 +643,7 @@
   "Clearance Z: {{value}} {{- units}}": "Vrijloophoogte Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Start-Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Eind-Z: {{value}} {{- units}}",
-  "None": "Geen"
+  "None": "Geen",
+  "Zigzag scan path": "",
+  "Probe odd rows right-to-left (serpentine) so the head continues from where the previous row ended, without the rapid back to the start of X at every row. Same points, same grid.": ""
 }

--- a/src/app/i18n/pt-br/resource.json
+++ b/src/app/i18n/pt-br/resource.json
@@ -644,5 +644,7 @@
   "Clearance Z: {{value}} {{- units}}": "Z de folga: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Z inicial: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Z final: {{value}} {{- units}}",
-  "None": "Nenhum"
+  "None": "Nenhum",
+  "Zigzag scan path": "",
+  "Probe odd rows right-to-left (serpentine) so the head continues from where the previous row ended, without the rapid back to the start of X at every row. Same points, same grid.": ""
 }

--- a/src/app/i18n/pt/resource.json
+++ b/src/app/i18n/pt/resource.json
@@ -644,5 +644,7 @@
   "Clearance Z: {{value}} {{- units}}": "Z de folga: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Z inicial: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Z final: {{value}} {{- units}}",
-  "None": "Nenhum"
+  "None": "Nenhum",
+  "Zigzag scan path": "",
+  "Probe odd rows right-to-left (serpentine) so the head continues from where the previous row ended, without the rapid back to the start of X at every row. Same points, same grid.": ""
 }

--- a/src/app/i18n/ru/resource.json
+++ b/src/app/i18n/ru/resource.json
@@ -645,5 +645,7 @@
   "Clearance Z: {{value}} {{- units}}": "Высота подъёма Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Начальная Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Конечная Z: {{value}} {{- units}}",
-  "None": "Нет"
+  "None": "Нет",
+  "Zigzag scan path": "",
+  "Probe odd rows right-to-left (serpentine) so the head continues from where the previous row ended, without the rapid back to the start of X at every row. Same points, same grid.": ""
 }

--- a/src/app/i18n/tr/resource.json
+++ b/src/app/i18n/tr/resource.json
@@ -643,5 +643,7 @@
   "Clearance Z: {{value}} {{- units}}": "Güvenlik Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Başlangıç Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Bitiş Z: {{value}} {{- units}}",
-  "None": "Yok"
+  "None": "Yok",
+  "Zigzag scan path": "",
+  "Probe odd rows right-to-left (serpentine) so the head continues from where the previous row ended, without the rapid back to the start of X at every row. Same points, same grid.": ""
 }

--- a/src/app/i18n/uk/resource.json
+++ b/src/app/i18n/uk/resource.json
@@ -645,5 +645,7 @@
   "Clearance Z: {{value}} {{- units}}": "Висота підйому Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Початкова Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Кінцева Z: {{value}} {{- units}}",
-  "None": "Немає"
+  "None": "Немає",
+  "Zigzag scan path": "",
+  "Probe odd rows right-to-left (serpentine) so the head continues from where the previous row ended, without the rapid back to the start of X at every row. Same points, same grid.": ""
 }

--- a/src/app/i18n/zh-cn/resource.json
+++ b/src/app/i18n/zh-cn/resource.json
@@ -642,5 +642,7 @@
   "Clearance Z: {{value}} {{- units}}": "安全高度Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "起始Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "终止Z: {{value}} {{- units}}",
-  "None": "无"
+  "None": "无",
+  "Zigzag scan path": "",
+  "Probe odd rows right-to-left (serpentine) so the head continues from where the previous row ended, without the rapid back to the start of X at every row. Same points, same grid.": ""
 }

--- a/src/app/i18n/zh-tw/resource.json
+++ b/src/app/i18n/zh-tw/resource.json
@@ -642,5 +642,7 @@
   "Clearance Z: {{value}} {{- units}}": "安全高度Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "起始Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "終止Z: {{value}} {{- units}}",
-  "None": "無"
+  "None": "無",
+  "Zigzag scan path": "",
+  "Probe odd rows right-to-left (serpentine) so the head continues from where the previous row ended, without the rapid back to the start of X at every row. Same points, same grid.": ""
 }

--- a/src/app/widgets/Autolevel/SetupProbeView.jsx
+++ b/src/app/widgets/Autolevel/SetupProbeView.jsx
@@ -16,6 +16,7 @@ const SetupProbeView = ({ state, actions }) => {
   const {
     stepX, stepY, startX, startY, endX, endY,
     clearanceZ, startZ, endZ, feedrate,
+    serpentine,
     probeState, probeProgress, canClick, units,
     validationErrors = {},
   } = state;
@@ -278,6 +279,24 @@ const SetupProbeView = ({ state, actions }) => {
               )}
             </div>
           </div>
+        </div>
+        <div className="checkbox" style={{ marginTop: 0, marginBottom: 5 }}>
+          <label>
+            <input
+              type="checkbox"
+              checked={!!serpentine}
+              onChange={actions.handleSerpentineChange}
+              disabled={isProbing}
+            />
+            {i18n._('Zigzag scan path')}
+            {' '}
+            <Infotip
+              placement="top"
+              content={i18n._('Probe odd rows right-to-left (serpentine) so the head continues from where the previous row ended, without the rapid back to the start of X at every row. Same points, same grid.')}
+            >
+              <i className="fa fa-info-circle text-muted" />
+            </Infotip>
+          </label>
         </div>
       </div>
       <div className={styles.section}>

--- a/src/app/widgets/Autolevel/index.jsx
+++ b/src/app/widgets/Autolevel/index.jsx
@@ -319,6 +319,9 @@ class AutolevelWidget extends PureComponent {
     handleProbeFeedrateChange: (event) => {
       this.setState({ feedrate: this.parseInputValue(event.target.value) });
     },
+    handleSerpentineChange: (event) => {
+      this.setState({ serpentine: event.target.checked });
+    },
 
     // Probe operations
     showTestProbeConfirmation: () => {
@@ -349,6 +352,7 @@ class AutolevelWidget extends PureComponent {
         startY, endY, stepY,
         clearanceZ, startZ, endZ,
         feedrate,
+        serpentine,
       } = this.state;
       // Calculate total points
       const numPointsX = Math.floor((endX - startX) / stepX) + 1;
@@ -385,6 +389,7 @@ class AutolevelWidget extends PureComponent {
         startZ,
         endZ,
         feedrate,
+        serpentine,
       });
 
       log.info('Starting probe sequence');
@@ -745,9 +750,11 @@ class AutolevelWidget extends PureComponent {
       startX, startY, endX, endY,
       clearanceZ, startZ, endZ,
       feedrate,
+      serpentine,
     } = this.state;
 
     this.config.set('minimized', minimized);
+    this.config.set('serpentine', serpentine);
 
     // Do not save config settings if the units just changed between in and mm
     if (this.unitsDidChange) {
@@ -825,6 +832,7 @@ class AutolevelWidget extends PureComponent {
       startZ: this.config.get('startZ', 5),
       endZ: this.config.get('endZ', -5),
       feedrate: this.config.get('feedrate', 25),
+      serpentine: this.config.get('serpentine', false),
       // Probe state
       probeState: PROBE_STATE_IDLE,
       probeProgress: { current: 0, total: 0, percentage: 0 },

--- a/src/server/controllers/Grbl/GrblController.js
+++ b/src/server/controllers/Grbl/GrblController.js
@@ -1792,6 +1792,7 @@ class GrblController {
             startZ,
             endZ,
             feedrate,
+            serpentine = false,
           } = params;
 
           if (mode === 'test') {
@@ -1816,6 +1817,7 @@ class GrblController {
             startY,
             endY,
             stepY,
+            serpentine,
           });
 
           // Reset probe state

--- a/src/server/controllers/Marlin/MarlinController.js
+++ b/src/server/controllers/Marlin/MarlinController.js
@@ -1757,6 +1757,7 @@ class MarlinController {
             startZ,
             endZ,
             feedrate,
+            serpentine = false,
           } = params;
 
           if (mode === 'test') {
@@ -1781,6 +1782,7 @@ class MarlinController {
             startY,
             endY,
             stepY,
+            serpentine,
           });
 
           // Reset probe state

--- a/src/server/controllers/Smoothie/SmoothieController.js
+++ b/src/server/controllers/Smoothie/SmoothieController.js
@@ -1681,6 +1681,7 @@ class SmoothieController {
             startZ,
             endZ,
             feedrate,
+            serpentine = false,
           } = params;
 
           if (mode === 'test') {
@@ -1705,6 +1706,7 @@ class SmoothieController {
             startY,
             endY,
             stepY,
+            serpentine,
           });
 
           // Reset probe state

--- a/src/server/controllers/TinyG/TinyGController.js
+++ b/src/server/controllers/TinyG/TinyGController.js
@@ -1809,6 +1809,7 @@ class TinyGController {
             startZ,
             endZ,
             feedrate,
+            serpentine = false,
           } = params;
 
           if (mode === 'test') {
@@ -1833,6 +1834,7 @@ class TinyGController {
             startY,
             endY,
             stepY,
+            serpentine,
           });
 
           // Reset probe state

--- a/src/server/lib/__tests__/autolevel.test.js
+++ b/src/server/lib/__tests__/autolevel.test.js
@@ -27,6 +27,72 @@ describe('autolevel', () => {
       ]);
     });
 
+    test('should reverse odd rows when serpentine is enabled', () => {
+      const positions = createProbeXYPoints({
+        startX: 0,
+        endX: 20,
+        stepX: 10,
+        startY: 0,
+        endY: 20,
+        stepY: 10,
+        serpentine: true,
+      });
+
+      expect(positions).toHaveLength(9);
+      expect(positions).toEqual([
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 20, y: 0 },
+        { x: 20, y: 10 }, // odd row: right to left
+        { x: 10, y: 10 },
+        { x: 0, y: 10 },
+        { x: 0, y: 20 }, // even row: left to right again
+        { x: 10, y: 20 },
+        { x: 20, y: 20 },
+      ]);
+    });
+
+    test('should end an even number of rows back at startX when serpentine is enabled', () => {
+      const positions = createProbeXYPoints({
+        startX: 0,
+        endX: 20,
+        stepX: 10,
+        startY: 0,
+        endY: 10,
+        stepY: 10,
+        serpentine: true,
+      });
+
+      expect(positions).toEqual([
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 20, y: 0 },
+        { x: 20, y: 10 }, // odd row: right to left
+        { x: 10, y: 10 },
+        { x: 0, y: 10 },
+      ]);
+    });
+
+    test('should probe the same set of points with and without serpentine', () => {
+      const area = {
+        startX: 0,
+        endX: 35,
+        stepX: 10,
+        startY: 0,
+        endY: 35,
+        stepY: 10,
+      };
+      const sortByXY = (a, b) => (a.y - b.y) || (a.x - b.x);
+
+      const positions = createProbeXYPoints(area);
+      const serpentinePositions = createProbeXYPoints({ ...area, serpentine: true });
+
+      expect(serpentinePositions).toHaveLength(positions.length);
+      expect([...serpentinePositions].sort(sortByXY)).toEqual([...positions].sort(sortByXY));
+      // Same grid, different visit order -- otherwise the option would be a no-op
+      expect(serpentinePositions).not.toEqual(positions);
+    });
+
     test('should generate points within range when end does not align with step', () => {
       const positions = createProbeXYPoints({
         startX: 0,

--- a/src/server/lib/autolevel.js
+++ b/src/server/lib/autolevel.js
@@ -319,6 +319,7 @@ const compensatePoint = (pt, surface, units = METRIC_UNITS) => {
  * @param {number} options.startY - Y-axis minimum
  * @param {number} options.endY - Y-axis maximum
  * @param {number} options.stepY - Y-axis step size
+ * @param {boolean} [options.serpentine] - Visit odd rows right-to-left
  * @returns {array} Array of probe XY points [{x, y}, ...]
  */
 export const createProbeXYPoints = (options) => {
@@ -329,14 +330,26 @@ export const createProbeXYPoints = (options) => {
     startY = 0,
     endY = 0,
     stepY = 10,
+    serpentine = false,
   } = ensurePlainObject(options);
 
   const positions = [];
 
+  let row = 0;
   for (let y = startY; y <= endY; y += stepY) {
+    const rowPositions = [];
     for (let x = startX; x <= endX; x += stepX) {
-      positions.push({ x, y });
+      rowPositions.push({ x, y });
     }
+    // Serpentine (zigzag) path: odd rows are probed right-to-left, so the head
+    // continues from where the previous row ended instead of rapiding back to
+    // startX. Same points, same grid -- only the visit order changes, and the
+    // per-row return rapid disappears from the path.
+    if (serpentine && (row % 2 === 1)) {
+      rowPositions.reverse();
+    }
+    positions.push(...rowPositions);
+    row += 1;
   }
 
   return positions;


### PR DESCRIPTION
## What

`createProbeXYPoints()` probes every row left-to-right, so between one row and the next the head rapids all the way back to `startX`. This adds an opt-in **Zigzag scan path** that probes odd rows right-to-left instead, letting the head continue from where the previous row ended.

The grid itself is untouched — same points, same spacing, same count. Only the visit order changes, and the per-row return rapid disappears from the path.

```
normal                     serpentine
o--o--o--o                 o--o--o--o
           \                        |
o--o--o--o  |              o--o--o--o
           \|              |
o--o--o--o                 o--o--o--o
```

## Why

On a wide probe area the return rapid at the start of each row is pure travel with nothing measured. Removing it shortens the path by construction. How much wall-clock time that saves depends on the column count and on the ratio between the rapid rate and the probing feedrate, so this PR does not put a number on it.

## Changes

- **`src/server/lib/autolevel.js`** — new `serpentine` option (default `false`) on `createProbeXYPoints()`; odd rows are reversed before being appended.
- **`src/server/controllers/{Grbl,Marlin,TinyG,Smoothie}Controller.js`** — read `serpentine` from the `autolevel:start` params and pass it to `createProbeXYPoints()`. All four controllers carry the same `autolevel:start` handler; wiring only one would leave a checkbox that silently does nothing on the other three.
- **`src/app/widgets/Autolevel/SetupProbeView.jsx`** — "Zigzag scan path" checkbox with an explanatory tooltip, placed at the end of the **Probe Area** section (it is a property of how the grid is traversed) and disabled while probing.
- **`src/app/widgets/Autolevel/index.jsx`** — `handleSerpentineChange`, the flag in the `autolevel:start` payload, and persistence through the widget config: loaded in `getInitialState()`, saved in `componentDidUpdate()` next to `minimized`, since it is not a unit-dependent value and must not go through the mm/inch mapping.
- **i18n** — the two new strings scanned into all 17 catalogues with `i18next-scanner`.

Default is off, so the probing path is byte-for-byte unchanged for anyone who does not tick the box.

## Tests

Three new cases in `src/server/lib/__tests__/autolevel.test.js`:

- **odd row count** (3 rows) — rows 0 and 2 left-to-right, row 1 right-to-left; the path ends at `endX`.
- **even row count** (2 rows) — the path ends back at `startX`.
- **set equality** — on a 4×4 grid, the serpentine path visits exactly the same set of points as the normal path (sorted comparison), has the same length, and is *not* in the same order.

`npx jest` → 241/241 passing (238 before). `npx eslint src/` → 0 errors, 3 warnings, unchanged from `master`.

## i18n

The two new strings were added with `i18next-scanner`, which is what fills the other 16 catalogues
with empty values — `src/app/lib/i18n.js` then falls back to English, so nothing renders blank. I
noticed you normally translate new keys yourself in the same commit (d502c22d), so say the word if
you would rather I fill any of them in.
