### PR TITLE
Docs: add cncjs-pendant-alexa to the pendants list

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ For a more complete introduction, see the [Introduction](https://github.com/cncj
 * [cncjs-pendant-lcd](https://github.com/cncjs/cncjs-pendant-lcd) - CNCjs Web Kiosk for Raspberry Pi Touch Displays.
 * [cncjs-pendant-ps3](https://github.com/cncjs/cncjs-pendant-ps3) - Dual Shock / PS3 Bluetooth Remote Pendant for CNCjs.
 * [cncjs-pendant-raspi-gpio](https://github.com/cncjs/cncjs-pendant-raspi-gpio) - Simple Raspberry Pi GPIO Pendant control for CNCjs.
+* [cncjs-pendant-alexa](https://github.com/thcasssio/cncjs-pendant-alexa) - Voice jog control via a custom Alexa skill ("Alexa, ask mill x plus 20"), with per-axis travel limits and state-gated jogging.
 
 ## Tablet UI
 


### PR DESCRIPTION
Adds [cncjs-pendant-alexa](https://github.com/thcasssio/cncjs-pendant-alexa) to the **Existing Pendants** list.

It is a standard external pendant (MIT, Node): it authenticates with the server's `~/.cncrc` secret like the other community pendants, exposes a small HTTPS endpoint for a self-hosted custom Alexa skill, and translates voice commands into `$J=` jogs — relative ("x plus 20") and absolute ("position x 130 y 100"), always in millimeters.

Safety model: per-axis travel limits per command, jogging refused unless the controller is Idle/Jog and the workflow is idle, no voice unlock on alarm, jog-cancel (0x85) by voice, and cryptographic verification (certificate + timestamp + skill id) of every request. Interaction models for en-US and pt-BR ship ready to paste; README documents the full skill + tunnel setup, including the wildcard-certificate gotcha that silently breaks Alexa endpoints behind Cloudflare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)