### PR TITLE
feat(gcode): show a progress bar for the running job

### DIFF
--- a/.changeset/gcode-progress-bar.md
+++ b/.changeset/gcode-progress-bar.md
@@ -1,0 +1,5 @@
+---
+"cncjs": patch
+---
+
+feat: show a progress bar for the running G-code job

--- a/src/app/widgets/GCode/GCodeStats.jsx
+++ b/src/app/widgets/GCode/GCodeStats.jsx
@@ -87,6 +87,7 @@ class GCodeStats extends PureComponent {
           <div className="row no-gutters" style={{ marginBottom: 10 }}>
             <div className="col-xs-12">
               <ProgressBar
+                style={{ marginBottom: 0 }}
                 bsStyle="info"
                 min={0}
                 max={total}

--- a/src/app/widgets/GCode/GCodeStats.jsx
+++ b/src/app/widgets/GCode/GCodeStats.jsx
@@ -1,6 +1,7 @@
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
+import { ProgressBar } from 'react-bootstrap';
 import i18n from 'app/lib/i18n';
 import {
   METRIC_UNITS
@@ -40,6 +41,11 @@ class GCodeStats extends PureComponent {
       const finishTime = formatISODateTime(state.finishTime);
       const elapsedTime = formatElapsedTime(state.elapsedTime);
       const remainingTime = formatRemainingTime(state.remainingTime);
+      // Received, not sent. Sent counts lines handed to the controller, which
+      // runs several seconds behind while its planner buffer drains, so a bar
+      // driven by it reads ahead of the tool and reaches 100% with the job
+      // still cutting. Received counts lines the controller acknowledged.
+      const progress = total > 0 ? Math.min(100, Math.round((received / total) * 100)) : 0;
 
       return (
         <div className={styles['gcode-stats']}>
@@ -77,6 +83,19 @@ class GCodeStats extends PureComponent {
               </table>
             </div>
           </div>
+          {total > 0 && (
+          <div className="row no-gutters" style={{ marginBottom: 10 }}>
+            <div className="col-xs-12">
+              <ProgressBar
+                bsStyle="info"
+                min={0}
+                max={total}
+                now={received}
+                label={`${progress}%`}
+              />
+            </div>
+          </div>
+          )}
           <div className="row no-gutters" style={{ marginBottom: 10 }}>
             <div className="col-xs-6">
               <div>{i18n._('Sent')}</div>


### PR DESCRIPTION
## What

The G-code widget already tracks `sent`, `received` and `total`, but shows them
only as counts. `12483 / 41902` answers "how far along is this job?" only after
you do the division in your head. This adds a bar above those numbers.

## Why `received` and not `sent`

`sent` counts lines handed to the controller. The controller runs behind that by
however much its planner buffer holds — seconds of motion on a job with short
segments. A bar driven by `sent` therefore reads ahead of where the tool
actually is, and reaches 100% while the machine is still cutting.

`received` counts lines the controller has acknowledged, so the bar tracks the
tool rather than the queue. It is the same number the widget already labels
"Received".

## Details

- Hidden while `total` is 0, since an empty bar beside em dashes is just noise.
- Uses the `ProgressBar` from react-bootstrap that the Autolevel widget already
  uses for its probing progress, so the two look the same.
- Percentage is clamped at 100 and rounded.

## Verification

- `npx eslint src/` — 0 errors, unchanged warning count from master.
- `npx jest` — 11 suites, 238 tests passing.
- Exercised by loading a job and watching the bar track the run on a Grbl
  machine (FluidNC on an ESP32).

No behaviour changes outside the widget's own render.
