### PR TITLE
feat: Marlin G28 homing fix + command() unit tests for Grbl, Marlin, Smoothie, TinyG

### DIFF
--- a/.changeset/cncjs-1000.md
+++ b/.changeset/cncjs-1000.md
@@ -1,0 +1,5 @@
+---
+"cncjs": patch
+---
+
+fix: Marlin G28 homing fix

--- a/src/server/controllers/Grbl/__tests__/GrblController.test.js
+++ b/src/server/controllers/Grbl/__tests__/GrblController.test.js
@@ -1,0 +1,968 @@
+/* eslint-env jest */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import GrblController from '../GrblController';
+import config from '../../../services/configstore';
+import monitor from '../../../services/monitor';
+import delay from '../../../lib/delay';
+import {
+  WORKFLOW_STATE_IDLE,
+  WORKFLOW_STATE_PAUSED,
+  WORKFLOW_STATE_RUNNING,
+} from '../../../lib/Workflow';
+import { createController } from '../../__tests__/helpers/createController';
+import {
+  TOOL_CHANGE_POLICY_IGNORE_M6_COMMANDS,
+  TOOL_CHANGE_POLICY_SEND_M6_COMMANDS,
+  TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_WCS,
+  TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_TLO,
+  TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_CUSTOM_PROBING,
+  WRITE_SOURCE_CLIENT,
+  WRITE_SOURCE_FEEDER,
+} from '../../constants';
+
+import logger from '../../../lib/logger';
+
+jest.mock('../../../lib/logger', () => {
+  const loggers = new Map();
+  const createLogger = () => ({
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    verbose: jest.fn(),
+    debug: jest.fn(),
+    silly: jest.fn(),
+  });
+  const logger = (namespace) => {
+    if (!loggers.has(namespace)) {
+      loggers.set(namespace, createLogger());
+    }
+    return loggers.get(namespace);
+  };
+  logger.loggers = loggers;
+  return {
+    __esModule: true,
+    default: logger,
+    getLevel: jest.fn(() => 'info'),
+    setLevel: jest.fn(),
+  };
+});
+
+const TOOL_CHANGE_CONFIG = {
+  'tool.toolChangeX': 0,
+  'tool.toolChangeY': 0,
+  'tool.toolChangeZ': 0,
+  'tool.toolProbeX': 0,
+  'tool.toolProbeY': 0,
+  'tool.toolProbeZ': 0,
+  'tool.toolProbeCommand': 'G38.2',
+  'tool.toolProbeDistance': 1,
+  'tool.toolProbeFeedrate': 10,
+  'tool.touchPlateHeight': 0,
+};
+
+const SHORT_PROGRAM = 'G0 X0\nG0 Y0\nM30';
+const LONG_PROGRAM = Array.from({ length: 20 }, () => 'G0 X10').join('\n');
+
+const TOOL_CHANGE_METRIC_PREFIX = [
+  'G4 P0.5\n',
+  'M5\n',
+  'G90\n',
+  'G53 G0 Z0.000\n',
+  'G53 G0 X0.000 Y0.000\n',
+  'G4 P0.5\n',
+  'M0\n',
+  'G53 G0 X0.000 Y0.000\n',
+  'G53 G0 Z0.000\n',
+  'G4 P0.5\n',
+];
+
+const TOOL_CHANGE_METRIC_SUFFIX = [
+  'G53 G0 Z0.000\n',
+  'G53 G0 X0.000 Y0.000\n',
+  'G4 P0.5\n',
+  'M0\n',
+  'G90\n',
+  'G0 X0 Y0\n',
+  'G0 Z0\n',
+  'M5\n',
+  'G4 P5\n',
+];
+
+const TOOL_CHANGE_IMPERIAL_PREFIX = [
+  'G4 P0.5\n',
+  'M5\n',
+  'G90\n',
+  'G53 G0 Z0.0000\n',
+  'G53 G0 X0.0000 Y0.0000\n',
+  'G4 P0.5\n',
+  'M0\n',
+  'G53 G0 X0.0000 Y0.0000\n',
+  'G53 G0 Z0.0000\n',
+  'G4 P0.5\n',
+];
+
+const TOOL_CHANGE_IMPERIAL_SUFFIX = [
+  'G53 G0 Z0.0000\n',
+  'G53 G0 X0.0000 Y0.0000\n',
+  'G4 P0.5\n',
+  'M0\n',
+  'G90\n',
+  'G0 X0 Y0\n',
+  'G0 Z0\n',
+  'M5\n',
+  'G4 P5\n',
+];
+
+const AUTOLEVEL_GRID_WRITES = [
+  'G90\n',
+  'G0 Z5\n',
+  'G0 X0 Y0\n',
+  'G0 Z1\n',
+  'G38.2 Z-1 F50\n',
+  'G0 Z5\n',
+  'G90\n',
+  'G0 Z5\n',
+  'G0 X10 Y0\n',
+  'G0 Z1\n',
+  'G38.2 Z-1 F100\n',
+  'G0 Z5\n',
+  'G90\n',
+  'G0 Z5\n',
+  'G0 X0 Y10\n',
+  'G0 Z1\n',
+  'G38.2 Z-1 F100\n',
+  'G0 Z5\n',
+  'G90\n',
+  'G0 Z5\n',
+  'G0 X10 Y10\n',
+  'G0 Z1\n',
+  'G38.2 Z-1 F100\n',
+  'G0 Z5\n',
+];
+
+const PROBE_FIXTURE = '0 0 -1.5 0 0 0 0 0 0\n10 0 -1 0 0 0 0 0 0\n';
+
+const activeControllers = [];
+const tempFiles = [];
+
+const getGrblLog = () => logger.loggers.get('controller:Grbl');
+
+const flushFeeder = (controller) => {
+  while (controller.feeder.size() > 0) {
+    controller.feeder.unhold();
+    controller.runner.parse('ok');
+  }
+};
+
+const setUnitsG20 = (controller) => {
+  controller.runner.state = {
+    ...controller.runner.state,
+    parserstate: {
+      ...controller.runner.state.parserstate,
+      modal: {
+        ...controller.runner.state.parserstate.modal,
+        units: 'G20',
+      },
+    },
+  };
+};
+
+const createTempFile = (content) => {
+  const filepath = path.join(os.tmpdir(), `grbl-controller-test-${process.pid}-${Date.now()}-${tempFiles.length}.gcode`);
+  fs.writeFileSync(filepath, content, 'utf8');
+  tempFiles.push(filepath);
+  return filepath;
+};
+
+const setup = (configValues = {}) => {
+  jest.spyOn(config, 'get').mockImplementation((key, defaultValue) => {
+    return (Object.prototype.hasOwnProperty.call(configValues, key) ? configValues[key] : defaultValue);
+  });
+  const { controller, writes } = createController(GrblController);
+  clearInterval(controller.queryTimer);
+  const socketEvents = [];
+  controller.sockets.test = { emit: (event, ...args) => socketEvents.push({ event, args }) };
+  activeControllers.push(controller);
+  return { controller, writes, socketEvents };
+};
+
+const serialWrites = (socketEvents) => {
+  return socketEvents
+    .filter(({ event }) => event === 'serialport:write')
+    .map(({ args }) => ({ data: args[0], source: args[1] && args[1].source }));
+};
+
+describe('GrblController', () => {
+  afterEach(() => {
+    while (activeControllers.length > 0) {
+      const controller = activeControllers.pop();
+      controller.destroy();
+    }
+    while (tempFiles.length > 0) {
+      fs.unlinkSync(tempFiles.pop());
+    }
+    jest.restoreAllMocks();
+  });
+
+  describe('realtime and simple commands', () => {
+    test.each([
+      ['feedhold', '!'],
+      ['cyclestart', '~'],
+      ['statusreport', '?'],
+      ['homing', '$H\n'],
+      ['sleep', '$SLP\n'],
+      ['unlock', '$X\n'],
+      ['reset', '\x18'],
+      ['jogCancel', '\x85'],
+    ])('%s writes %j without a trailing newline for realtime bytes', (cmd, expected) => {
+      const { controller, writes, socketEvents } = setup();
+
+      controller.command(cmd);
+
+      expect(writes.map(write => write.data)).toEqual([expected]);
+      expect(serialWrites(socketEvents)).toEqual([{ data: expected, source: WRITE_SOURCE_CLIENT }]);
+    });
+
+    test('reset stops the workflow and clears the feeder', () => {
+      const { controller, writes } = setup();
+
+      controller.command('gcode', ['G0 X0', 'G0 Y0']);
+      controller.command('reset');
+
+      expect(writes.map(write => write.data)).toEqual(['G0 X0\n', '\x18']);
+      expect(controller.feeder.size()).toBe(0);
+      expect(controller.workflow.state).toBe(WORKFLOW_STATE_IDLE);
+    });
+  });
+
+  describe('feedOverride', () => {
+    test.each([
+      [0, '\x90'],
+      [10, '\x91'],
+      [-10, '\x92'],
+      [1, '\x93'],
+      [-1, '\x94'],
+    ])('%i%% writes the realtime override byte', (value, expected) => {
+      const { controller, writes } = setup();
+
+      controller.command('feedOverride', value);
+
+      expect(writes.map(write => write.data)).toEqual([expected]);
+    });
+
+    test('values without a dedicated realtime byte write nothing', () => {
+      const { controller, writes } = setup();
+
+      controller.command('feedOverride', 5);
+
+      expect(writes).toEqual([]);
+    });
+  });
+
+  describe('spindleOverride', () => {
+    test.each([
+      [0, '\x99'],
+      [10, '\x9a'],
+      [-10, '\x9b'],
+      [1, '\x9c'],
+      [-1, '\x9d'],
+    ])('%i%% writes the realtime override byte', (value, expected) => {
+      const { controller, writes } = setup();
+
+      controller.command('spindleOverride', value);
+
+      expect(writes.map(write => write.data)).toEqual([expected]);
+    });
+
+    test('values without a dedicated realtime byte write nothing', () => {
+      const { controller, writes } = setup();
+
+      controller.command('spindleOverride', 5);
+
+      expect(writes).toEqual([]);
+    });
+  });
+
+  describe('rapidOverride', () => {
+    test.each([
+      [0, '\x95'],
+      [100, '\x95'],
+      [50, '\x96'],
+      [25, '\x97'],
+    ])('%i%% writes the realtime override byte', (value, expected) => {
+      const { controller, writes } = setup();
+
+      controller.command('rapidOverride', value);
+
+      expect(writes.map(write => write.data)).toEqual([expected]);
+    });
+
+    test('values without a dedicated realtime byte write nothing', () => {
+      const { controller, writes } = setup();
+
+      controller.command('rapidOverride', 75);
+
+      expect(writes).toEqual([]);
+    });
+  });
+
+  describe('lasertest', () => {
+    test('lasertest:on with default args turns the laser on without a timed burn', () => {
+      const { controller, writes, socketEvents } = setup();
+
+      controller.command('lasertest:on');
+      flushFeeder(controller);
+
+      expect(writes.map(write => write.data)).toEqual(['G1F1\n', 'M3S0\n']);
+      expect(serialWrites(socketEvents).map(write => write.source)).toEqual([
+        WRITE_SOURCE_FEEDER,
+        WRITE_SOURCE_FEEDER,
+      ]);
+    });
+
+    test('lasertest:on with power and duration burns for the given duration', () => {
+      const { controller, writes } = setup();
+
+      controller.command('lasertest:on', 50, 100, 1000);
+      flushFeeder(controller);
+
+      expect(writes.map(write => write.data)).toEqual([
+        'G1F1\n',
+        'M3S500\n',
+        'G4P0.1\n',
+        'M5S0\n',
+      ]);
+    });
+
+    test('lasertest:off turns the laser off', () => {
+      const { controller, writes } = setup();
+
+      controller.command('lasertest:off');
+
+      expect(writes.map(write => write.data)).toEqual(['M5S0\n']);
+    });
+  });
+
+  describe('feeder', () => {
+    test('feeder:feed feeds commands to the feeder queue', () => {
+      const { controller, writes, socketEvents } = setup();
+
+      controller.command('feeder:feed', ['G0 X0', 'G0 Y0']);
+      controller.runner.parse('ok');
+
+      expect(writes.map(write => write.data)).toEqual(['G0 X0\n', 'G0 Y0\n']);
+      expect(serialWrites(socketEvents).map(write => write.source)).toEqual([
+        WRITE_SOURCE_FEEDER,
+        WRITE_SOURCE_FEEDER,
+      ]);
+    });
+
+    test('feeder:start writes cycle start and then the next queued line', () => {
+      const { controller, writes, socketEvents } = setup();
+
+      controller.command('feeder:feed', ['G0 X0', 'G0 Y0']);
+      controller.command('feeder:start');
+
+      expect(writes.map(write => write.data)).toEqual(['G0 X0\n', '~', 'G0 Y0\n']);
+      expect(serialWrites(socketEvents).map(write => write.source)).toEqual([
+        WRITE_SOURCE_FEEDER,
+        WRITE_SOURCE_CLIENT,
+        WRITE_SOURCE_FEEDER,
+      ]);
+    });
+
+    test('feeder:start writes only cycle start when the queue is empty', () => {
+      const { controller, writes } = setup();
+
+      controller.command('feeder:start');
+
+      expect(writes.map(write => write.data)).toEqual(['~']);
+    });
+
+    test('feeder:start writes nothing while a program is running', () => {
+      const { controller, writes } = setup();
+
+      controller.command('gcode', ['G0 X0']);
+      controller.command('gcode:load', 'test.gcode', SHORT_PROGRAM);
+      controller.command('gcode:start');
+      const writesAfterStart = writes.length;
+      controller.command('feeder:start');
+
+      expect(writes.length).toBe(writesAfterStart);
+    });
+
+    test('feeder:stop discards the queued lines', () => {
+      const { controller, writes } = setup();
+
+      controller.command('gcode', ['G0 X0', 'G0 Y0']);
+      controller.command('feeder:stop');
+      controller.runner.parse('ok');
+
+      expect(writes.map(write => write.data)).toEqual(['G0 X0\n']);
+      expect(controller.feeder.size()).toBe(0);
+    });
+  });
+
+  describe('gcode', () => {
+    test('gcode feeds a multi-line program one line at a time, filtering empty lines and comments', () => {
+      const { controller, writes, socketEvents } = setup();
+
+      controller.command('gcode', 'G0 X0\n\n   \n; comment\n(parenthesized)\nG0 Y0');
+      controller.runner.parse('ok');
+
+      expect(writes.map(write => write.data)).toEqual(['G0 X0\n', 'G0 Y0\n']);
+      expect(controller.feeder.size()).toBe(0);
+      expect(serialWrites(socketEvents).map(write => write.source)).toEqual([
+        WRITE_SOURCE_FEEDER,
+        WRITE_SOURCE_FEEDER,
+      ]);
+    });
+  });
+
+  describe('sender workflow', () => {
+    test('gcode:load loads the program with an appended dwell and reports the sender state', () => {
+      const { controller, writes, socketEvents } = setup();
+      const callback = jest.fn();
+
+      controller.command('gcode:load', 'test.gcode', SHORT_PROGRAM, {}, callback);
+
+      const [err, json] = callback.mock.calls[0];
+      expect(err).toBe(null);
+      expect(json).toEqual(expect.objectContaining({
+        name: 'test.gcode',
+        total: 4,
+        sent: 0,
+        received: 0,
+      }));
+      expect(controller.sender.state.gcode).toBe(`${SHORT_PROGRAM}\n%wait ; Wait for the planner to empty`);
+      expect(writes).toEqual([]);
+      expect(socketEvents.some(({ event }) => event === 'gcode:load')).toBe(true);
+    });
+
+    test('gcode:load accepts a callback in the context position', () => {
+      const { controller } = setup();
+      const callback = jest.fn();
+
+      controller.command('gcode:load', 'test.gcode', 'G0 X0', callback);
+
+      const [err, json] = callback.mock.calls[0];
+      expect(err).toBe(null);
+      expect(json).toEqual(expect.objectContaining({ name: 'test.gcode', total: 2 }));
+    });
+
+    // The controller appends the %wait dwell before Sender.load validates its input,
+    // so empty and non-string programs are string-concatenated into a non-empty
+    // program instead of reaching the Invalid G-code error branch.
+    test.each([
+      ['an empty program', '', 1],
+      ['a non-string program', 42, 2],
+    ])('gcode:load accepts %s because the appended dwell makes it non-empty', (name, gcode, total) => {
+      const { controller } = setup();
+      const callback = jest.fn();
+
+      controller.command('gcode:load', 'test.gcode', gcode, callback);
+
+      const [err, json] = callback.mock.calls[0];
+      expect(err).toBe(null);
+      expect(json).toEqual(expect.objectContaining({ name: 'test.gcode', total }));
+    });
+
+    test('gcode:unload stops the workflow and clears the sender', () => {
+      const { controller, writes, socketEvents } = setup();
+
+      controller.command('gcode:load', 'test.gcode', SHORT_PROGRAM);
+      controller.command('gcode:start');
+      controller.command('gcode:unload');
+
+      expect(writes.map(write => write.data)).toEqual(['G0 X0\n', 'G0 Y0\n', 'M30\n', 'G4 P0.5\n']);
+      expect(controller.workflow.state).toBe(WORKFLOW_STATE_IDLE);
+      expect(controller.sender.state.name).toBe('');
+      expect(controller.sender.state.gcode).toBe('');
+      expect(socketEvents.some(({ event }) => event === 'gcode:unload')).toBe(true);
+    });
+
+    test('gcode:start streams the program up to the buffer limit and reports running state', () => {
+      const { controller, writes } = setup();
+
+      controller.command('gcode:load', 'test.gcode', SHORT_PROGRAM);
+      controller.command('gcode:start');
+
+      expect(writes.map(write => write.data)).toEqual(['G0 X0\n', 'G0 Y0\n', 'M30\n', 'G4 P0.5\n']);
+      expect(controller.workflow.state).toBe(WORKFLOW_STATE_RUNNING);
+    });
+
+    test('gcode:start streams a long program until the character-counting buffer is full', () => {
+      const { controller, writes } = setup();
+
+      controller.command('gcode:load', 'test.gcode', LONG_PROGRAM);
+      controller.command('gcode:start');
+
+      expect(writes.map(write => write.data)).toEqual(Array.from({ length: 17 }, () => 'G0 X10\n'));
+      expect(controller.sender.state.sent).toBe(17);
+    });
+
+    test('gcode:pause writes feed hold and holds off the sender', () => {
+      const { controller, writes } = setup();
+
+      controller.command('gcode:load', 'test.gcode', LONG_PROGRAM);
+      controller.command('gcode:start');
+      controller.command('gcode:pause');
+
+      expect(writes.map(write => write.data)).toEqual([...Array.from({ length: 17 }, () => 'G0 X10\n'), '!']);
+      expect(controller.workflow.state).toBe(WORKFLOW_STATE_PAUSED);
+      expect(controller.sender.state.hold).toBe(true);
+    });
+
+    test('gcode:resume writes cycle start and streams the next line', () => {
+      const { controller, writes } = setup();
+
+      controller.command('gcode:load', 'test.gcode', LONG_PROGRAM);
+      controller.command('gcode:start');
+      controller.command('gcode:pause');
+      controller.command('gcode:resume');
+
+      expect(writes.map(write => write.data)).toEqual([
+        ...Array.from({ length: 17 }, () => 'G0 X10\n'),
+        '!',
+        '~',
+        'G0 X10\n',
+      ]);
+      expect(controller.workflow.state).toBe(WORKFLOW_STATE_RUNNING);
+      expect(controller.sender.state.hold).toBe(false);
+    });
+
+    test('gcode:stop stops the workflow without writing', () => {
+      const { controller, writes } = setup();
+
+      controller.command('gcode:load', 'test.gcode', LONG_PROGRAM);
+      controller.command('gcode:start');
+      controller.command('gcode:stop');
+
+      expect(writes.map(write => write.data)).toEqual(Array.from({ length: 17 }, () => 'G0 X10\n'));
+      expect(controller.workflow.state).toBe(WORKFLOW_STATE_IDLE);
+      expect(controller.sender.state.sent).toBe(0);
+    });
+
+    test('gcode:stop with force holds and then resets while the machine is running', async () => {
+      const { controller, writes, socketEvents } = setup();
+
+      controller.runner.state.status.activeState = 'Run';
+      controller.state = controller.runner.state;
+      controller.command('gcode:stop', { force: true });
+      controller.runner.state.status.activeState = 'Hold';
+      await delay(600);
+
+      expect(writes.map(write => write.data)).toEqual(['!', '\x18']);
+      expect(serialWrites(socketEvents).map(write => write.source)).toEqual([
+        WRITE_SOURCE_CLIENT,
+        WRITE_SOURCE_CLIENT,
+      ]);
+    });
+
+    test('gcode:stop with force resets a machine that is already on hold', async () => {
+      const { controller, writes } = setup();
+
+      controller.runner.state.status.activeState = 'Hold';
+      controller.state = controller.runner.state;
+      controller.command('gcode:stop', { force: true });
+      await delay(600);
+
+      expect(writes.map(write => write.data)).toEqual(['\x18']);
+    });
+
+    test('gcode:stop with force writes nothing when the machine is neither running nor on hold', async () => {
+      const { controller, writes } = setup();
+
+      controller.runner.state.status.activeState = 'Idle';
+      controller.state = controller.runner.state;
+      controller.command('gcode:stop', { force: true });
+      await delay(600);
+
+      expect(writes).toEqual([]);
+    });
+  });
+
+  describe('deprecated aliases', () => {
+    test.each([
+      ['start', 'gcode:start'],
+      ['pause', 'gcode:pause'],
+      ['resume', 'gcode:resume'],
+      ['stop', 'gcode:stop'],
+    ])('%s produces the same writes as %s after loading a program', (alias, canonical) => {
+      const canonicalSetup = setup();
+      const aliasSetup = setup();
+      const { controller: canonicalController, writes: canonicalWrites } = canonicalSetup;
+      const { controller: aliasController, writes: aliasWrites } = aliasSetup;
+
+      canonicalController.command('gcode:load', 'test.gcode', SHORT_PROGRAM);
+      aliasController.command('gcode:load', 'test.gcode', SHORT_PROGRAM);
+
+      if (canonical !== 'gcode:start') {
+        canonicalController.command('gcode:start');
+        aliasController.command('gcode:start');
+      }
+      if (canonical === 'gcode:resume') {
+        canonicalController.command('gcode:pause');
+        aliasController.command('gcode:pause');
+      }
+
+      canonicalController.command(canonical);
+      aliasController.command(alias);
+
+      expect(aliasWrites.map(write => write.data)).toEqual(canonicalWrites.map(write => write.data));
+      expect(aliasWrites.length).toBeGreaterThan(0);
+    });
+
+    test.each([
+      ['start', 'gcode:start'],
+      ['pause', 'gcode:pause'],
+      ['resume', 'gcode:resume'],
+      ['stop', 'gcode:stop'],
+    ])('%s logs a deprecation warning', (alias) => {
+      const { controller } = setup();
+
+      controller.command(alias);
+
+      expect(getGrblLog().warn).toHaveBeenCalledWith(
+        `Warning: The "${alias}" command is deprecated and will be removed in a future release.`
+      );
+    });
+  });
+
+  describe('tool:change', () => {
+    test.each([
+      ['IGNORE_M6_COMMANDS', TOOL_CHANGE_POLICY_IGNORE_M6_COMMANDS, []],
+      ['SEND_M6_COMMANDS', TOOL_CHANGE_POLICY_SEND_M6_COMMANDS, []],
+      ['MANUAL_TOOL_CHANGE_WCS', TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_WCS, [
+        'G91 G38.2 F10 Z-1\n',
+        'G10 L20 P1 Z0\n',
+      ]],
+      ['MANUAL_TOOL_CHANGE_TLO', TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_TLO, [
+        'G91 G38.2 F10 Z-1\n',
+        'G4 P1\n',
+        'G43.1 Z0\n',
+      ]],
+    ])('%s drives the full tool change and probing sequence', (name, policy, probingLines) => {
+      const { controller, writes } = setup({
+        ...TOOL_CHANGE_CONFIG,
+        'tool.toolChangePolicy': policy,
+      });
+
+      controller.command('tool:change');
+      flushFeeder(controller);
+
+      expect(writes.map(write => write.data)).toEqual([
+        ...TOOL_CHANGE_METRIC_PREFIX,
+        ...probingLines,
+        ...TOOL_CHANGE_METRIC_SUFFIX,
+      ]);
+    });
+
+    test('MANUAL_TOOL_CHANGE_CUSTOM_PROBING sends the configured custom probing commands', () => {
+      const { controller, writes } = setup({
+        ...TOOL_CHANGE_CONFIG,
+        'tool.toolChangePolicy': TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_CUSTOM_PROBING,
+        'tool.toolProbeCustomCommands': 'G38.2 Z-5\nG92 Z0',
+      });
+
+      controller.command('tool:change');
+      flushFeeder(controller);
+
+      expect(writes.map(write => write.data)).toEqual([
+        ...TOOL_CHANGE_METRIC_PREFIX,
+        'G38.2 Z-5\n',
+        'G92 Z0\n',
+        ...TOOL_CHANGE_METRIC_SUFFIX,
+      ]);
+    });
+
+    test('imperial units convert the tool change and probing values to inches', () => {
+      const { controller, writes } = setup({
+        ...TOOL_CHANGE_CONFIG,
+        'tool.toolChangePolicy': TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_WCS,
+      });
+      setUnitsG20(controller);
+
+      controller.command('tool:change');
+      flushFeeder(controller);
+
+      expect(writes.map(write => write.data)).toEqual([
+        ...TOOL_CHANGE_IMPERIAL_PREFIX,
+        'G91 G38.2 F0.3937 Z-0.0394\n',
+        'G10 L20 P1 Z0\n',
+        ...TOOL_CHANGE_IMPERIAL_SUFFIX,
+      ]);
+    });
+  });
+
+  describe('autolevel', () => {
+    test('autolevel:start in test mode probes once at the current position', () => {
+      const { controller, writes } = setup();
+
+      controller.command('autolevel:start', {
+        mode: 'test',
+        clearanceZ: 5,
+        startZ: 1,
+        endZ: -1,
+        feedrate: 100,
+      });
+      flushFeeder(controller);
+
+      expect(writes.map(write => write.data)).toEqual([
+        'G90\n',
+        'G0 Z5\n',
+        'G0 Z1\n',
+        'G38.2 Z-1 F100\n',
+        'G0 Z5\n',
+      ]);
+      expect(controller.probeState.config).toBe(null);
+    });
+
+    test('autolevel:start in full mode probes a 2x2 grid and seeds the probe state', () => {
+      const { controller, writes } = setup();
+      const params = {
+        startX: 0,
+        endX: 10,
+        stepX: 10,
+        startY: 0,
+        endY: 10,
+        stepY: 10,
+        clearanceZ: 5,
+        startZ: 1,
+        endZ: -1,
+        feedrate: 100,
+      };
+
+      controller.command('autolevel:start', params);
+      flushFeeder(controller);
+
+      expect(writes.map(write => write.data)).toEqual(AUTOLEVEL_GRID_WRITES);
+      expect(controller.probeState.probePoints).toEqual([
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 0, y: 10 },
+        { x: 10, y: 10 },
+      ]);
+      expect(controller.probeState.probedPositions).toEqual([]);
+      expect(controller.probeState.minZ).toBe(null);
+      expect(controller.probeState.maxZ).toBe(null);
+      expect(controller.probeState.config).toEqual(params);
+    });
+
+    test('autolevel:stop resets the controller and clears the probe state', () => {
+      const { controller, writes } = setup();
+
+      controller.probeState = {
+        probedPositions: [{ x: 0, y: 0, z: 0 }],
+        probePoints: [{ x: 0, y: 0 }],
+        minZ: 0,
+        maxZ: 0,
+        config: { startX: 0 },
+      };
+
+      controller.command('autolevel:stop');
+
+      expect(writes.map(write => write.data)).toEqual(['\x18']);
+      expect(controller.probeState).toEqual({
+        probedPositions: [],
+        probePoints: [],
+        minZ: null,
+        maxZ: null,
+        config: null,
+      });
+    });
+
+    test('autolevel:getProbeState reports the current probe state', () => {
+      const { controller } = setup();
+
+      controller.probeState.minZ = -1.5;
+      controller.probeState.maxZ = -1;
+
+      const callback = jest.fn();
+      controller.command('autolevel:getProbeState', null, callback);
+
+      expect(callback).toHaveBeenCalledWith(null, { state: controller.probeState });
+    });
+
+    test('autolevel:loadFromFile loads nine-column probe rows', async () => {
+      const { controller } = setup();
+      const filepath = createTempFile(PROBE_FIXTURE);
+      const callback = jest.fn();
+
+      controller.command('autolevel:loadFromFile', filepath, callback);
+      await delay(100);
+
+      const [err, result] = callback.mock.calls[0];
+      expect(err).toBe(null);
+      expect(result.success).toBe(true);
+      expect(controller.probeState.probedPositions).toEqual([
+        { x: 0, y: 0, z: -1.5 },
+        { x: 10, y: 0, z: -1 },
+      ]);
+      expect(controller.probeState.minZ).toBe(-1.5);
+      expect(controller.probeState.maxZ).toBe(-1);
+    });
+
+    test('autolevel:loadFromFile reports an error for a missing file', async () => {
+      const { controller } = setup();
+      const filepath = path.join(os.tmpdir(), 'grbl-controller-test-does-not-exist.gcode');
+      const callback = jest.fn();
+
+      controller.command('autolevel:loadFromFile', filepath, callback);
+      await delay(100);
+
+      const [err, result] = callback.mock.calls[0];
+      expect(err).toEqual(expect.stringContaining('ENOENT'));
+      expect(result).toEqual({ success: false, state: null });
+      expect(controller.probeState.probedPositions).toEqual([]);
+    });
+
+    test('autolevel:saveToFile writes nine-column probe rows', async () => {
+      const { controller } = setup();
+      const filepath = path.join(os.tmpdir(), `grbl-controller-test-${process.pid}-${Date.now()}-save.gcode`);
+      tempFiles.push(filepath);
+      controller.probeState.probedPositions = [
+        { x: 0, y: 0, z: -1.5 },
+        { x: 10, y: 0, z: -1 },
+      ];
+      const callback = jest.fn();
+
+      controller.command('autolevel:saveToFile', filepath, callback);
+      await delay(100);
+
+      const [err, result] = callback.mock.calls[0];
+      expect(err).toBe(null);
+      expect(result).toEqual({ success: true, filepath });
+      expect(fs.readFileSync(filepath, 'utf8')).toBe('0 0 -1.5 0 0 0 0 0 0\n10 0 -1 0 0 0 0 0 0');
+    });
+
+    test('autolevel:applyProbeCompensation returns compensated gcode via the callback', () => {
+      const { controller } = setup();
+      const callback = jest.fn();
+
+      controller.command('autolevel:applyProbeCompensation', {
+        gcode: 'G1 X0 Y0 F100',
+        probeData: [
+          { x: 0, y: 0, z: 0 },
+          { x: 10, y: 0, z: 0 },
+          { x: 0, y: 10, z: 0 },
+          { x: 10, y: 10, z: 0 },
+        ],
+      }, callback);
+
+      expect(callback).toHaveBeenCalledWith(null, {
+        compensatedGcode: 'G1 F100 X0.000 Y0.000 Z0.000',
+      });
+    });
+
+    test('autolevel:applyProbeCompensation passes gcode through when probe data is insufficient', () => {
+      const { controller } = setup();
+      const callback = jest.fn();
+
+      controller.command('autolevel:applyProbeCompensation', {
+        gcode: 'G1 X0 Y0 F100',
+        probeData: [
+          { x: 0, y: 0, z: 0 },
+          { x: 10, y: 0, z: 0 },
+        ],
+      }, callback);
+
+      expect(callback).toHaveBeenCalledWith(null, { compensatedGcode: 'G1 X0 Y0 F100' });
+    });
+  });
+
+  describe('macro and watchdir', () => {
+    test('macro:run feeds the macro content through the feeder', () => {
+      const { controller, writes } = setup({
+        macros: [{ id: 'm1', name: 'Square', content: 'G0 X0\nG0 Y0' }],
+      });
+      const callback = jest.fn();
+
+      controller.command('macro:run', 'm1', {}, callback);
+      flushFeeder(controller);
+
+      expect(writes.map(write => write.data)).toEqual(['G0 X0\n', 'G0 Y0\n']);
+      expect(callback).toHaveBeenCalledWith(null);
+    });
+
+    test('macro:run with an unknown id writes nothing and skips the callback', () => {
+      const { controller, writes } = setup({ macros: [] });
+      const callback = jest.fn();
+
+      controller.command('macro:run', 'nope', {}, callback);
+
+      expect(writes).toEqual([]);
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    test('macro:load loads the macro content into the sender', () => {
+      const { controller, writes } = setup({
+        macros: [{ id: 'm1', name: 'Square', content: 'G0 X0' }],
+      });
+      const callback = jest.fn();
+
+      controller.command('macro:load', 'm1', {}, callback);
+
+      const [err, json] = callback.mock.calls[0];
+      expect(err).toBe(null);
+      expect(json).toEqual(expect.objectContaining({ name: 'Square', total: 2 }));
+      expect(writes).toEqual([]);
+    });
+
+    test('watchdir:load reads the file through monitor and loads it', () => {
+      const { controller, writes } = setup();
+      const readFileSpy = jest.spyOn(monitor, 'readFile').mockImplementation((file, callback) => {
+        callback(null, 'G0 X0\nG0 Y0');
+      });
+      const callback = jest.fn();
+
+      controller.command('watchdir:load', 'part.nc', callback);
+
+      expect(readFileSpy).toHaveBeenCalledWith('part.nc', expect.any(Function));
+      const [err, json] = callback.mock.calls[0];
+      expect(err).toBe(null);
+      expect(json).toEqual(expect.objectContaining({ name: 'part.nc', total: 3 }));
+      expect(writes).toEqual([]);
+    });
+
+    test('watchdir:load reports monitor read errors', () => {
+      const { controller, writes } = setup();
+      const failure = new Error('read failure');
+      jest.spyOn(monitor, 'readFile').mockImplementation((file, callback) => {
+        callback(failure);
+      });
+      const callback = jest.fn();
+
+      controller.command('watchdir:load', 'part.nc', callback);
+
+      expect(callback).toHaveBeenCalledWith(failure);
+      expect(writes).toEqual([]);
+    });
+  });
+
+  describe('negative', () => {
+    test('unknown command writes nothing', () => {
+      const { controller, writes, socketEvents } = setup();
+
+      controller.command('nonexistent');
+
+      expect(writes).toEqual([]);
+      expect(serialWrites(socketEvents)).toEqual([]);
+    });
+
+    test('commands write nothing when the connection is closed', () => {
+      const { controller, writes } = setup();
+      controller.connection.isOpen = false;
+
+      controller.command('feedhold');
+      controller.command('homing');
+      controller.command('gcode', ['G0 X0']);
+      controller.command('gcode:load', 'test.gcode', SHORT_PROGRAM);
+      controller.command('gcode:start');
+
+      expect(writes).toEqual([]);
+    });
+  });
+});

--- a/src/server/controllers/Marlin/MarlinController.js
+++ b/src/server/controllers/Marlin/MarlinController.js
@@ -1450,7 +1450,8 @@ class MarlinController {
         'homing': () => {
           this.event.trigger('homing');
 
-          this.writeln('G28.2 X Y Z');
+          // G28: Auto Home
+          this.writeln('G28');
         },
         'sleep': () => {
           this.event.trigger('sleep');

--- a/src/server/controllers/Marlin/__tests__/MarlinController.test.js
+++ b/src/server/controllers/Marlin/__tests__/MarlinController.test.js
@@ -1,33 +1,701 @@
 /* eslint-env jest */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import logger from '../../../lib/logger';
+import config from '../../../services/configstore';
+import monitor from '../../../services/monitor';
 import MarlinController from '../MarlinController';
+import {
+  TOOL_CHANGE_POLICY_IGNORE_M6_COMMANDS,
+  TOOL_CHANGE_POLICY_SEND_M6_COMMANDS,
+  TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_WCS,
+  TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_TLO,
+  TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_CUSTOM_PROBING,
+  WRITE_SOURCE_CLIENT,
+  WRITE_SOURCE_FEEDER,
+  WRITE_SOURCE_SENDER,
+} from '../../constants';
+import { createController } from '../../__tests__/helpers/createController';
+
+jest.mock('../../../lib/logger', () => {
+  const levels = ['error', 'warn', 'info', 'verbose', 'debug', 'silly'];
+  const log = levels.reduce((acc, level) => {
+    acc[level] = jest.fn();
+    return acc;
+  }, {});
+  const factory = () => log;
+  factory.levels = levels;
+  factory.getLevel = () => 'info';
+  factory.setLevel = () => {};
+  return factory;
+});
+
+const log = logger('controller:Marlin');
+
+// mapPositionToUnits returns formatted strings ('0.000' metric, '0.0000' imperial),
+// so tool:change lines embed those exact zero representations.
+const METRIC_ZERO = '0.000';
+const IMPERIAL_ZERO = '0.0000';
+
+const PINNED_TOOL_CHANGE_CONFIG = {
+  'tool.toolChangeX': 0,
+  'tool.toolChangeY': 0,
+  'tool.toolChangeZ': 0,
+  'tool.toolProbeX': 0,
+  'tool.toolProbeY': 0,
+  'tool.toolProbeZ': 0,
+  'tool.toolProbeCommand': 'G38.2',
+  'tool.toolProbeDistance': 1,
+  'tool.toolProbeFeedrate': 10,
+  'tool.touchPlateHeight': 0,
+  'tool.toolProbeCustomCommands': 'G53 G0 X5\nG4 P100',
+};
+
+const toolChangeSequence = (policyLines, zero = METRIC_ZERO) => [
+  'G4 S0.5\n',
+  'M5\n',
+  'G90\n',
+  `G53 G0 Z${zero}\n`,
+  `G53 G0 X${zero} Y${zero}\n`,
+  'G4 S0.5\n',
+  'M0\n',
+  `G53 G0 X${zero} Y${zero}\n`,
+  `G53 G0 Z${zero}\n`,
+  'G4 S0.5\n',
+  ...policyLines,
+  `G53 G0 Z${zero}\n`,
+  `G53 G0 X${zero} Y${zero}\n`,
+  'G4 S0.5\n',
+  'M0\n',
+  'G90\n',
+  'G0 X0 Y0\n',
+  'G0 Z0\n',
+  'M5\n',
+  'G4 S5\n',
+];
+
+// Feeder-fed lines advance one per machine "ok"; in tests the queue is drained
+// by clearing any hold and pulling the next line until nothing is left.
+const drainFeeder = (controller, writes) => {
+  for (;;) {
+    const written = writes.length;
+    controller.feeder.unhold();
+    controller.feeder.next();
+    if (controller.feeder.size() === 0 && writes.length === written) {
+      break;
+    }
+  }
+};
 
 describe('MarlinController', () => {
   let controller;
+  let writes;
+  let tempDir;
+  let configGetSpy;
+
+  const setup = () => {
+    const harness = createController(MarlinController);
+    controller = harness.controller;
+    writes = harness.writes;
+    return harness;
+  };
+
+  const mockConfigGet = (overrides = {}) => {
+    configGetSpy.mockImplementation((key, defaultValue) => {
+      if (Object.prototype.hasOwnProperty.call(overrides, key)) {
+        return overrides[key];
+      }
+      if (key === 'events') {
+        return [];
+      }
+      return defaultValue;
+    });
+  };
+
+  beforeEach(() => {
+    configGetSpy = jest.spyOn(config, 'get').mockImplementation((key, defaultValue) => (
+      key === 'events' ? [] : defaultValue
+    ));
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'marlin-controller-test-'));
+  });
 
   afterEach(() => {
     if (controller) {
       controller.destroy();
       controller = null;
     }
+    writes = null;
+    jest.restoreAllMocks();
+    fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
-  describe('command', () => {
-    test('homing sends the Marlin auto home command', () => {
-      controller = new MarlinController({ io: null }, {
-        port: '/dev/null',
-        baudrate: 115200,
-        rtscts: false,
-      });
-
-      const writes = [];
-      controller.connection = {
-        isOpen: true,
-        write: (data) => writes.push(data),
-      };
-
+  describe('basic commands', () => {
+    test('homing writes the Marlin auto home command', () => {
+      setup();
       controller.command('homing');
+      expect(writes).toEqual([{ data: 'G28\n', context: { source: WRITE_SOURCE_CLIENT } }]);
+    });
 
-      expect(writes).toEqual(['G28\n']);
+    test('reset writes the emergency stop command', () => {
+      setup();
+      controller.command('reset');
+      expect(writes).toEqual([{ data: 'M112\n', context: { source: WRITE_SOURCE_CLIENT } }]);
+    });
+
+    test('feedhold triggers the event without writing', () => {
+      setup();
+      const trigger = jest.spyOn(controller.event, 'trigger');
+      controller.command('feedhold');
+      expect(writes).toEqual([]);
+      expect(trigger).toHaveBeenCalledWith('feedhold');
+    });
+
+    test('cyclestart triggers the event without writing', () => {
+      setup();
+      const trigger = jest.spyOn(controller.event, 'trigger');
+      controller.command('cyclestart');
+      expect(writes).toEqual([]);
+      expect(trigger).toHaveBeenCalledWith('cyclestart');
+    });
+
+    test('sleep triggers the event without writing', () => {
+      setup();
+      const trigger = jest.spyOn(controller.event, 'trigger');
+      controller.command('sleep');
+      expect(writes).toEqual([]);
+      expect(trigger).toHaveBeenCalledWith('sleep');
+    });
+
+    test('unlock is a no-op', () => {
+      setup();
+      const trigger = jest.spyOn(controller.event, 'trigger');
+      controller.command('unlock');
+      expect(writes).toEqual([]);
+      expect(trigger).not.toHaveBeenCalled();
+    });
+
+    test('lasertest:off writes M5 with client source', () => {
+      setup();
+      controller.command('lasertest:off');
+      expect(writes).toEqual([{ data: 'M5\n', context: { source: WRITE_SOURCE_CLIENT } }]);
+    });
+
+    test('statusreport is not a known command', () => {
+      setup();
+      controller.command('statusreport');
+      expect(writes).toEqual([]);
+      expect(log.error).toHaveBeenCalledWith('Unknown command: statusreport');
+    });
+
+    test('commands do not write when the connection is closed', () => {
+      setup();
+      controller.connection.isOpen = false;
+      controller.command('homing');
+      controller.command('reset');
+      controller.command('gcode', 'G0 X1');
+      controller.command('lasertest:off');
+      expect(writes).toEqual([]);
+    });
+  });
+
+  describe('feedOverride', () => {
+    test.each([
+      [100, 0, 'M220S100\n'],
+      [100, 450, 'M220S500\n'],
+      [100, -200, 'M220S10\n'],
+      [100, 50, 'M220S150\n'],
+    ])('ovF=%i value=%i feeds %s', (ovF, value, expected) => {
+      setup();
+      controller.runner.state.ovF = ovF;
+      controller.command('feedOverride', value);
+      expect(writes).toEqual([{ data: expected, context: { source: WRITE_SOURCE_FEEDER } }]);
+    });
+
+    test('updates the runner feed override state', () => {
+      setup();
+      controller.runner.state.ovF = 100;
+      controller.command('feedOverride', 50);
+      expect(controller.runner.state.ovF).toBe(150);
+    });
+  });
+
+  describe('spindleOverride', () => {
+    test.each([
+      [100, 0, 'M221S100\n'],
+      [100, 450, 'M221S500\n'],
+      [100, -200, 'M221S10\n'],
+      [100, 50, 'M221S150\n'],
+    ])('ovS=%i value=%i feeds %s', (ovS, value, expected) => {
+      setup();
+      controller.runner.state.ovS = ovS;
+      controller.command('spindleOverride', value);
+      expect(writes).toEqual([{ data: expected, context: { source: WRITE_SOURCE_FEEDER } }]);
+    });
+
+    test('updates the runner spindle override state', () => {
+      setup();
+      controller.runner.state.ovS = 100;
+      controller.command('spindleOverride', 50);
+      expect(controller.runner.state.ovS).toBe(150);
+    });
+  });
+
+  describe('rapidOverride', () => {
+    test('is unsupported and writes nothing', () => {
+      setup();
+      controller.command('rapidOverride', 50);
+      expect(writes).toEqual([]);
+    });
+  });
+
+  describe('motor and laser', () => {
+    test('motor:enable feeds M17', () => {
+      setup();
+      controller.command('motor:enable');
+      expect(writes).toEqual([{ data: 'M17\n', context: { source: WRITE_SOURCE_FEEDER } }]);
+    });
+
+    test('motor:disable feeds M18', () => {
+      setup();
+      controller.command('motor:disable');
+      expect(writes).toEqual([{ data: 'M18\n', context: { source: WRITE_SOURCE_FEEDER } }]);
+    });
+
+    test('laser:on with default args feeds M3S0', () => {
+      setup();
+      controller.command('laser:on');
+      expect(writes).toEqual([{ data: 'M3S0\n', context: { source: WRITE_SOURCE_FEEDER } }]);
+    });
+
+    test('laser:on with explicit power and maxS feeds the scaled S value', () => {
+      setup();
+      controller.command('laser:on', 50, 1000);
+      expect(writes).toEqual([{ data: 'M3S500\n', context: { source: WRITE_SOURCE_FEEDER } }]);
+    });
+
+    test('lasertest:on with a duration feeds M3S, dwell and M5', () => {
+      setup();
+      controller.command('lasertest:on', 100, 50, 255);
+      drainFeeder(controller, writes);
+      expect(writes.map(write => write.data)).toEqual(['M3S255\n', 'G4 P50\n', 'M5\n']);
+      writes.forEach(write => expect(write.context.source).toBe(WRITE_SOURCE_FEEDER));
+    });
+
+    test('lasertest:on without a duration feeds only M3S', () => {
+      setup();
+      controller.command('lasertest:on', 50);
+      expect(writes.map(write => write.data)).toEqual(['M3S127.5\n']);
+      writes.forEach(write => expect(write.context.source).toBe(WRITE_SOURCE_FEEDER));
+    });
+  });
+
+  describe('gcode and feeder', () => {
+    test('gcode feeds one write per line and empty lines are filtered', () => {
+      setup();
+      controller.command('gcode', 'G0 X1\n\nG0 Y2');
+      expect(writes).toEqual([{ data: 'G0 X1\n', context: { source: WRITE_SOURCE_FEEDER } }]);
+
+      controller.runner.emit('ok', { raw: 'ok' });
+      expect(writes).toEqual([
+        { data: 'G0 X1\n', context: { source: WRITE_SOURCE_FEEDER } },
+        { data: 'G0 Y2\n', context: { source: WRITE_SOURCE_FEEDER } },
+      ]);
+    });
+
+    test('gcode drops blank and non-string lines', () => {
+      setup();
+      controller.command('gcode', ['', '  ', null, 'G0 X1']);
+      expect(writes.map(write => write.data)).toEqual(['G0 X1\n']);
+    });
+
+    test('feeder:feed writes through the feeder source', () => {
+      setup();
+      controller.command('feeder:feed', 'G0 X1\nG0 Y2');
+      expect(writes.map(write => write.data)).toEqual(['G0 X1\n']);
+      expect(writes[0].context.source).toBe(WRITE_SOURCE_FEEDER);
+    });
+
+    test('feeder:start unholds the feeder and resumes feeding', () => {
+      setup();
+      controller.command('gcode', 'M109 S200');
+      controller.command('gcode', 'G0 X1');
+      expect(writes.map(write => write.data)).toEqual(['M109 S200\n']);
+
+      controller.command('feeder:start');
+      expect(writes.map(write => write.data)).toEqual(['M109 S200\n', 'G0 X1\n']);
+      expect(writes[1].context.source).toBe(WRITE_SOURCE_FEEDER);
+    });
+
+    test('feeder:start does nothing while a program is running', () => {
+      setup();
+      controller.command('gcode:load', 'test', 'G0 X0\nG0 Y2');
+      controller.command('gcode:start');
+      controller.command('gcode', 'G0 X9');
+      controller.command('feeder:start');
+      expect(writes.map(write => write.data)).toEqual(['G0 X0\n']);
+    });
+
+    test('feeder:stop clears the queue', () => {
+      setup();
+      controller.command('gcode', ['G0 X1', 'G0 Y2']);
+      expect(writes.map(write => write.data)).toEqual(['G0 X1\n']);
+
+      controller.command('feeder:stop');
+      controller.runner.emit('ok', { raw: 'ok' });
+      expect(writes.map(write => write.data)).toEqual(['G0 X1\n']);
+    });
+  });
+
+  describe('gcode:load', () => {
+    test('loads a program and returns the sender state via callback', () => {
+      setup();
+      const callback = jest.fn();
+      controller.command('gcode:load', 'test', 'G0 X0\nG0 Y2', callback);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      const [err, json] = callback.mock.calls[0];
+      expect(err).toBeNull();
+      expect(json.name).toBe('test');
+      expect(json.total).toBe(3); // two program lines plus the %wait dwell line
+      expect(json.sent).toBe(0);
+      expect(json.received).toBe(0);
+      expect(writes).toEqual([]);
+    });
+
+    test('an empty program still loads because the dwell line is appended before Sender.load', () => {
+      // MarlinController concatenates the %wait dwell line with the user G-code
+      // before calling Sender.load, so Sender.load's empty-input guard never trips.
+      setup();
+      const callback = jest.fn();
+      controller.command('gcode:load', 'test', '', callback);
+
+      const [err, json] = callback.mock.calls[0];
+      expect(err).toBeNull();
+      expect(json.total).toBe(1);
+      expect(writes).toEqual([]);
+    });
+  });
+
+  describe('sender workflow', () => {
+    test('gcode:start sends the first program line', () => {
+      setup();
+      controller.command('gcode:load', 'test', 'G0 X0\nG0 Y2');
+      controller.command('gcode:start');
+      expect(writes).toEqual([{ data: 'G0 X0\n', context: { source: WRITE_SOURCE_SENDER } }]);
+      expect(controller.workflow.state).toBe('running');
+    });
+
+    test('gcode:pause holds and gcode:resume sends the next line', () => {
+      setup();
+      controller.command('gcode:load', 'test', 'G0 X0\nG0 Y2');
+      controller.command('gcode:start');
+      controller.command('gcode:pause');
+      expect(controller.workflow.state).toBe('paused');
+      expect(writes.map(write => write.data)).toEqual(['G0 X0\n']);
+
+      controller.command('gcode:resume');
+      expect(writes.map(write => write.data)).toEqual(['G0 X0\n', 'G0 Y2\n']);
+      expect(writes[1].context.source).toBe(WRITE_SOURCE_SENDER);
+    });
+
+    test('gcode:stop stops the workflow and rewinds the sender', () => {
+      setup();
+      controller.command('gcode:load', 'test', 'G0 X0\nG0 Y2');
+      controller.command('gcode:start');
+      controller.command('gcode:stop');
+      expect(controller.workflow.state).toBe('idle');
+      expect(writes.map(write => write.data)).toEqual(['G0 X0\n']);
+
+      controller.command('gcode:start');
+      expect(writes.map(write => write.data)).toEqual(['G0 X0\n', 'G0 X0\n']);
+    });
+
+    test('gcode:unload clears the sender', () => {
+      setup();
+      controller.command('gcode:load', 'test', 'G0 X0\nG0 Y2');
+      controller.command('gcode:start');
+      controller.command('gcode:unload');
+      expect(controller.sender.state.gcode).toBe('');
+      expect(controller.sender.state.total).toBe(0);
+      expect(controller.workflow.state).toBe('idle');
+      expect(writes.map(write => write.data)).toEqual(['G0 X0\n']);
+    });
+
+    test.each([
+      ['start', 'gcode:start'],
+      ['stop', 'gcode:stop'],
+      ['pause', 'gcode:pause'],
+      ['resume', 'gcode:resume'],
+    ])('deprecated alias "%s" matches "%s" and logs a warning', (alias, canonical) => {
+      const canonicalHarness = createController(MarlinController);
+      canonicalHarness.controller.command('gcode:load', 'test', 'G0 X0\nG0 Y2');
+      canonicalHarness.controller.command(canonical);
+
+      setup();
+      controller.command('gcode:load', 'test', 'G0 X0\nG0 Y2');
+      controller.command(alias);
+
+      expect(writes).toEqual(canonicalHarness.writes);
+      expect(log.warn).toHaveBeenCalledWith(`Warning: The "${alias}" command is deprecated and will be removed in a future release.`);
+      canonicalHarness.controller.destroy();
+    });
+
+    test('macro:run feeds the macro content', () => {
+      setup();
+      mockConfigGet({ macros: [{ id: 'm1', name: 'M1', content: 'G0 X1\nG0 Y2' }] });
+      const callback = jest.fn();
+      controller.command('macro:run', 'm1', callback);
+      expect(callback).toHaveBeenCalledWith(null);
+      expect(writes.map(write => write.data)).toEqual(['G0 X1\n']);
+    });
+
+    test('macro:run with an unknown id calls back without writing', () => {
+      setup();
+      mockConfigGet({ macros: [] });
+      const callback = jest.fn();
+      controller.command('macro:run', 'missing', callback);
+      expect(writes).toEqual([]);
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    test('macro:load loads the macro content into the sender', () => {
+      setup();
+      mockConfigGet({ macros: [{ id: 'm1', name: 'M1', content: 'G0 X1' }] });
+      const callback = jest.fn();
+      controller.command('macro:load', 'm1', callback);
+
+      const [err, json] = callback.mock.calls[0];
+      expect(err).toBeNull();
+      expect(json.name).toBe('M1');
+      expect(json.total).toBe(2);
+    });
+
+    test('watchdir:load reads the file via monitor and loads it', () => {
+      setup();
+      jest.spyOn(monitor, 'readFile').mockImplementation((file, callback) => callback(null, 'G0 X5\nG0 Y5'));
+      const callback = jest.fn();
+      controller.command('watchdir:load', 'watched.gcode', callback);
+
+      const [err, json] = callback.mock.calls[0];
+      expect(err).toBeNull();
+      expect(json.name).toBe('watched.gcode');
+      expect(json.total).toBe(3);
+    });
+  });
+
+  describe('tool:change', () => {
+    const runToolChange = (policy, units = 'G21') => {
+      mockConfigGet({ ...PINNED_TOOL_CHANGE_CONFIG, 'tool.toolChangePolicy': policy });
+      setup();
+      controller.runner.state.modal.units = units;
+      controller.command('tool:change');
+      drainFeeder(controller, writes);
+    };
+
+    test.each([
+      ['IGNORE_M6_COMMANDS', TOOL_CHANGE_POLICY_IGNORE_M6_COMMANDS, []],
+      ['SEND_M6_COMMANDS', TOOL_CHANGE_POLICY_SEND_M6_COMMANDS, []],
+      ['MANUAL_TOOL_CHANGE_WCS', TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_WCS, ['G91 G38.2 F10 Z-1\n', 'G92 Z0\n']],
+      ['MANUAL_TOOL_CHANGE_TLO', TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_TLO, ['G91 G38.2 F10 Z-1\n', 'G4 S1\n', 'G92 Z0\n']],
+      ['MANUAL_TOOL_CHANGE_CUSTOM_PROBING', TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_CUSTOM_PROBING, ['G53 G0 X5\n', 'G4 P100\n']],
+    ])('%s writes the exact sequence', (name, policy, policyLines) => {
+      runToolChange(policy);
+      expect(writes.map(write => write.data)).toEqual(toolChangeSequence(policyLines));
+      writes.forEach(write => expect(write.context.source).toBe(WRITE_SOURCE_FEEDER));
+    });
+
+    test('converts pinned values to imperial units (G20)', () => {
+      runToolChange(TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_WCS, 'G20');
+      expect(writes.map(write => write.data)).toEqual(toolChangeSequence([
+        'G91 G38.2 F0.3937 Z-0.0394\n',
+        'G92 Z0\n',
+      ], IMPERIAL_ZERO));
+    });
+  });
+
+  describe('autolevel', () => {
+    test('autolevel:start in test mode probes once at the current position', () => {
+      setup();
+      controller.command('autolevel:start', { mode: 'test', clearanceZ: 5, startZ: 2, endZ: -1, feedrate: 100 });
+      drainFeeder(controller, writes);
+      expect(writes.map(write => write.data)).toEqual([
+        'G90\n',
+        'G0 Z5\n',
+        'G0 Z2\n',
+        'G38.2 Z-1 F100\n',
+        'G0 Z5\n',
+      ]);
+      writes.forEach(write => expect(write.context.source).toBe(WRITE_SOURCE_FEEDER));
+      expect(controller.probeState.probePoints).toEqual([]);
+    });
+
+    test('autolevel:start in full mode generates the exact probe sequence', () => {
+      setup();
+      controller.command('autolevel:start', {
+        mode: 'full',
+        startX: 0,
+        endX: 10,
+        stepX: 10,
+        startY: 0,
+        endY: 10,
+        stepY: 10,
+        clearanceZ: 5,
+        startZ: 2,
+        endZ: -1,
+        feedrate: 100,
+      });
+      drainFeeder(controller, writes);
+      expect(writes.map(write => write.data)).toEqual([
+        'G90\n', 'G0 Z5\n', 'G0 X0 Y0\n', 'G0 Z2\n', 'G38.2 Z-1 F50\n', 'G0 Z5\n',
+        'G90\n', 'G0 Z5\n', 'G0 X10 Y0\n', 'G0 Z2\n', 'G38.2 Z-1 F100\n', 'G0 Z5\n',
+        'G90\n', 'G0 Z5\n', 'G0 X0 Y10\n', 'G0 Z2\n', 'G38.2 Z-1 F100\n', 'G0 Z5\n',
+        'G90\n', 'G0 Z5\n', 'G0 X10 Y10\n', 'G0 Z2\n', 'G38.2 Z-1 F100\n', 'G0 Z5\n',
+      ]);
+      expect(controller.probeState.probePoints).toEqual([
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 0, y: 10 },
+        { x: 10, y: 10 },
+      ]);
+      expect(controller.probeState.config).toEqual({
+        startX: 0,
+        endX: 10,
+        stepX: 10,
+        startY: 0,
+        endY: 10,
+        stepY: 10,
+        clearanceZ: 5,
+        startZ: 2,
+        endZ: -1,
+        feedrate: 100,
+      });
+    });
+
+    test('autolevel:stop resets the machine and clears the probe state', () => {
+      setup();
+      controller.probeState.probedPositions = [{ x: 1, y: 2, z: 3 }];
+      controller.probeState.probePoints = [{ x: 1, y: 2 }];
+      controller.probeState.pendingProbeCapture = true;
+
+      controller.command('autolevel:stop');
+      expect(writes).toEqual([{ data: 'M112\n', context: { source: WRITE_SOURCE_CLIENT } }]);
+      expect(controller.probeState).toEqual({
+        probedPositions: [],
+        probePoints: [],
+        minZ: null,
+        maxZ: null,
+        config: null,
+      });
+    });
+
+    test('autolevel:getProbeState returns the current probe state', () => {
+      setup();
+      const probeState = {
+        probedPositions: [{ x: 1, y: 2, z: 0.5 }],
+        minZ: 0.5,
+        maxZ: 0.5,
+        probePoints: [{ x: 1, y: 2 }],
+        config: null,
+        pendingProbeCapture: false,
+      };
+      controller.probeState = probeState;
+
+      const callback = jest.fn();
+      controller.command('autolevel:getProbeState', null, callback);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      const [err, res] = callback.mock.calls[0];
+      expect(err).toBeNull();
+      expect(res.state).toBe(probeState);
+    });
+
+    test('autolevel:loadFromFile populates the probe state from a 9-column fixture', async () => {
+      setup();
+      const filepath = path.join(tempDir, 'probe-fixture.txt');
+      fs.writeFileSync(filepath, '1 2 0.5 0 0 0 0 0 0\n3 4 -1.25 0 0 0 0 0 0\n5 6 2 0 0 0 0 0 0\n');
+
+      const result = await new Promise((resolve) => {
+        controller.command('autolevel:loadFromFile', filepath, (err, res) => resolve({ err, res }));
+      });
+      expect(result.err).toBeNull();
+      expect(result.res.success).toBe(true);
+      expect(controller.probeState.probedPositions).toEqual([
+        { x: 1, y: 2, z: 0.5 },
+        { x: 3, y: 4, z: -1.25 },
+        { x: 5, y: 6, z: 2 },
+      ]);
+      expect(controller.probeState.minZ).toBe(-1.25);
+      expect(controller.probeState.maxZ).toBe(2);
+      expect(writes).toEqual([]);
+    });
+
+    test('autolevel:loadFromFile calls back with an error message for a missing file', async () => {
+      setup();
+      const result = await new Promise((resolve) => {
+        controller.command('autolevel:loadFromFile', path.join(tempDir, 'missing.txt'), (err, res) => resolve({ err, res }));
+      });
+      // The handler passes err.message (a string) instead of an Error instance.
+      expect(result.err).toEqual(expect.any(String));
+      expect(result.res).toEqual({ success: false, state: null });
+    });
+
+    test('autolevel:saveToFile writes 9-column rows and calls back with success', async () => {
+      setup();
+      const filepath = path.join(tempDir, 'probe-out.txt');
+      controller.probeState.probedPositions = [{ x: 1, y: 2, z: 0.5 }, { x: 3, y: 4, z: -1.25 }];
+
+      const result = await new Promise((resolve) => {
+        controller.command('autolevel:saveToFile', filepath, (err, res) => resolve({ err, res }));
+      });
+      expect(result.err).toBeNull();
+      expect(result.res).toEqual({ success: true, filepath });
+      expect(fs.readFileSync(filepath, 'utf8')).toBe('1 2 0.5 0 0 0 0 0 0\n3 4 -1.25 0 0 0 0 0 0');
+    });
+
+    test('autolevel:applyProbeCompensation returns compensated G-code via callback', () => {
+      setup();
+      const callback = jest.fn();
+      const probeData = [
+        { x: 0, y: 0, z: 0 },
+        { x: 10, y: 0, z: 0 },
+        { x: 0, y: 10, z: 0 },
+        { x: 10, y: 10, z: 0 },
+      ];
+      controller.command('autolevel:applyProbeCompensation', { gcode: 'G0 X5 Y5', probeData }, callback);
+      expect(callback).toHaveBeenCalledWith(null, { compensatedGcode: 'G0 X5.000 Y5.000 Z0.000' });
+    });
+
+    test('autolevel:applyProbeCompensation passes G-code through when probe data is insufficient', () => {
+      setup();
+      const callback = jest.fn();
+      controller.command('autolevel:applyProbeCompensation', { gcode: 'G0 X5 Y5', probeData: [{ x: 0, y: 0, z: 0 }] }, callback);
+      expect(callback).toHaveBeenCalledWith(null, { compensatedGcode: 'G0 X5 Y5' });
+    });
+
+    test('completing a G38.2 line queries the position and flags probe capture', () => {
+      setup();
+      controller.probeState.probePoints = [{ x: 0, y: 0 }, { x: 10, y: 0 }];
+      controller.history.writeLine = 'G38.2 Z-1';
+
+      controller.runner.emit('ok', { raw: 'ok' });
+      expect(writes).toEqual([{ data: 'M114\n', context: { source: WRITE_SOURCE_CLIENT } }]);
+      expect(controller.probeState.pendingProbeCapture).toBe(true);
+      expect(controller.history.writeLine).toBe('');
+    });
+
+    test('the position report after a probe is captured into the probe state', () => {
+      setup();
+      controller.probeState.probePoints = [{ x: 0, y: 0 }, { x: 10, y: 0 }];
+      controller.history.writeLine = 'G38.2 Z-1';
+      controller.runner.emit('ok', { raw: 'ok' });
+
+      controller.runner.state.pos = { x: '1.000', y: '2.000', z: '3.000' };
+      controller.runner.emit('pos', { raw: 'X:1.000 Y:2.000 Z:3.000 E:0.000' });
+      expect(controller.probeState.pendingProbeCapture).toBe(false);
+      expect(controller.probeState.probedPositions).toEqual([{ x: 1, y: 2, z: 3 }]);
+      expect(controller.probeState.minZ).toBe(3);
+      expect(controller.probeState.maxZ).toBe(3);
     });
   });
 });

--- a/src/server/controllers/Marlin/__tests__/MarlinController.test.js
+++ b/src/server/controllers/Marlin/__tests__/MarlinController.test.js
@@ -1,0 +1,33 @@
+/* eslint-env jest */
+import MarlinController from '../MarlinController';
+
+describe('MarlinController', () => {
+  let controller;
+
+  afterEach(() => {
+    if (controller) {
+      controller.destroy();
+      controller = null;
+    }
+  });
+
+  describe('command', () => {
+    test('homing sends the Marlin auto home command', () => {
+      controller = new MarlinController({ io: null }, {
+        port: '/dev/null',
+        baudrate: 115200,
+        rtscts: false,
+      });
+
+      const writes = [];
+      controller.connection = {
+        isOpen: true,
+        write: (data) => writes.push(data),
+      };
+
+      controller.command('homing');
+
+      expect(writes).toEqual(['G28\n']);
+    });
+  });
+});

--- a/src/server/controllers/Smoothie/__tests__/SmoothieController.test.js
+++ b/src/server/controllers/Smoothie/__tests__/SmoothieController.test.js
@@ -1,0 +1,844 @@
+/* eslint-env jest */
+import fsp from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import SmoothieController from '../SmoothieController';
+import config from '../../../services/configstore';
+import monitor from '../../../services/monitor';
+import * as autolevel from '../../../lib/autolevel';
+import { createController } from '../../__tests__/helpers/createController';
+import {
+  TOOL_CHANGE_POLICY_IGNORE_M6_COMMANDS,
+  TOOL_CHANGE_POLICY_SEND_M6_COMMANDS,
+  TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_WCS,
+  TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_TLO,
+  TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_CUSTOM_PROBING,
+  WRITE_SOURCE_CLIENT,
+  WRITE_SOURCE_FEEDER,
+} from '../../constants';
+import { SMOOTHIE_ACTIVE_STATE_HOLD } from '../constants';
+
+const originalConfigGet = config.get;
+let configOverrides = {};
+let configGetSpy = null;
+let controllers = [];
+const tempFiles = [];
+
+const setConfig = (overrides) => {
+  Object.assign(configOverrides, overrides);
+};
+
+const create = () => {
+  const { controller, writes } = createController(SmoothieController);
+  controllers.push(controller);
+  return { controller, writes };
+};
+
+const written = (writes) => writes.map((entry) => entry.data);
+
+// SmoothieController forwards no context to connection.write, but the source
+// distinction is observable on the 'serialport:write' socket event.
+const captureSerialWrites = (controller) => {
+  const events = [];
+  controller.sockets['test-socket'] = {
+    emit: (event, ...args) => {
+      if (event === 'serialport:write') {
+        events.push({ data: args[0], context: args[1] });
+      }
+    },
+  };
+  return events;
+};
+
+// Drives the feeder queue to completion: each runner "ok" releases the next
+// queued line, and feeder holds (M0) are lifted the same way.
+const pumpFeeder = (controller) => {
+  for (;;) {
+    if (controller.feeder.state.hold) {
+      controller.feeder.unhold();
+    }
+    if (controller.feeder.size() === 0 && !controller.feeder.isPending()) {
+      return;
+    }
+    controller.runner.emit('ok', { raw: 'ok' });
+  }
+};
+
+const seedStatus = (controller, patch) => {
+  controller.runner.state = {
+    ...controller.runner.state,
+    status: { ...controller.runner.state.status, ...patch },
+  };
+};
+
+const seedModal = (controller, patch) => {
+  controller.runner.state = {
+    ...controller.runner.state,
+    parserstate: {
+      ...controller.runner.state.parserstate,
+      modal: { ...controller.runner.state.parserstate.modal, ...patch },
+    },
+  };
+};
+
+const waitForCallback = (callback) => new Promise((resolve, reject) => {
+  let attempts = 0;
+  const check = () => {
+    if (callback.mock.calls.length > 0) {
+      resolve();
+      return;
+    }
+    if (attempts > 1000) {
+      reject(new Error('callback was never invoked'));
+      return;
+    }
+    attempts += 1;
+    setImmediate(check);
+  };
+  check();
+});
+
+beforeEach(() => {
+  configOverrides = {};
+  configGetSpy = jest.spyOn(config, 'get').mockImplementation((key, defaultValue) => (
+    Object.prototype.hasOwnProperty.call(configOverrides, key)
+      ? configOverrides[key]
+      : originalConfigGet.call(config, key, defaultValue)
+  ));
+});
+
+afterEach(async () => {
+  configGetSpy.mockRestore();
+  controllers.forEach((controller) => controller.destroy());
+  controllers = [];
+  await Promise.all(tempFiles.splice(0).map((file) => fsp.unlink(file).catch(() => {})));
+});
+
+describe('SmoothieController', () => {
+  describe('simple commands', () => {
+    test('feedhold writes suspend with the client write source', () => {
+      const { controller, writes } = create();
+      const serialEvents = captureSerialWrites(controller);
+
+      controller.command('feedhold');
+
+      expect(written(writes)).toEqual(['suspend\n']);
+      expect(serialEvents[0]).toEqual({ data: 'suspend\n', context: { source: WRITE_SOURCE_CLIENT } });
+    });
+
+    test('cyclestart writes resume', () => {
+      const { controller, writes } = create();
+
+      controller.command('cyclestart');
+
+      expect(written(writes)).toEqual(['resume\n']);
+    });
+
+    test('statusreport writes the realtime question mark without a newline', () => {
+      const { controller, writes } = create();
+
+      controller.command('statusreport');
+
+      expect(written(writes)).toEqual(['?']);
+      expect(controller.actionMask.replyStatusReport).toBe(true);
+    });
+
+    test('homing writes the Smoothie homing command', () => {
+      const { controller, writes } = create();
+
+      controller.command('homing');
+
+      expect(written(writes)).toEqual(['$H\n']);
+    });
+
+    test('sleep writes nothing (not supported)', () => {
+      const { controller, writes } = create();
+
+      controller.command('sleep');
+
+      expect(writes).toEqual([]);
+    });
+
+    test('unlock writes the alarm unlock command', () => {
+      const { controller, writes } = create();
+
+      controller.command('unlock');
+
+      expect(written(writes)).toEqual(['$X\n']);
+    });
+
+    test('reset writes a realtime control-x and drops the feeder queue', () => {
+      const { controller, writes } = create();
+
+      controller.command('gcode', 'G0 X1');
+      controller.command('reset');
+
+      expect(written(writes)).toEqual(['G0 X1\n', '\x18']);
+      expect(controller.feeder.size()).toBe(0);
+    });
+  });
+
+  describe('overrides', () => {
+    test.each([
+      [0, 150, 'M220S100', 100],
+      [100, 150, 'M220S200', 200],
+      [-10, 15, 'M220S10', 10],
+      [30, 100, 'M220S130', 130],
+    ])('feedOverride %p with ovF=%p writes %s', (value, seededOvF, expectedCommand, expectedOvF) => {
+      const { controller, writes } = create();
+      seedStatus(controller, { ovF: seededOvF });
+
+      controller.command('feedOverride', value);
+
+      expect(written(writes)).toEqual([`${expectedCommand}\n`]);
+      expect(controller.runner.state.status.ovF).toBe(expectedOvF);
+    });
+
+    test.each([
+      [0, 150, 'M221S100', 100],
+      [100, 150, 'M221S200', 200],
+      [-10, 15, 'M221S10', 10],
+      [30, 100, 'M221S130', 130],
+    ])('spindleOverride %p with ovS=%p writes %s', (value, seededOvS, expectedCommand, expectedOvS) => {
+      const { controller, writes } = create();
+      seedStatus(controller, { ovS: seededOvS });
+
+      controller.command('spindleOverride', value);
+
+      expect(written(writes)).toEqual([`${expectedCommand}\n`]);
+      expect(controller.runner.state.status.ovS).toBe(expectedOvS);
+    });
+
+    test('override lines are fed through the feeder write source', () => {
+      const { controller, writes } = create();
+      const serialEvents = captureSerialWrites(controller);
+      seedStatus(controller, { ovF: 100 });
+
+      controller.command('feedOverride', 30);
+
+      expect(written(writes)).toEqual(['M220S130\n']);
+      expect(serialEvents[0].data).toBe('M220S130\n');
+      expect(serialEvents[0].context.source).toBe(WRITE_SOURCE_FEEDER);
+    });
+
+    test('feedOverride without a seeded ovF writes M220SNaN because the runner status is unguarded', () => {
+      const { controller, writes } = create();
+
+      controller.command('feedOverride', 30);
+
+      expect(written(writes)).toEqual(['M220SNaN\n']);
+      expect(Number.isNaN(controller.runner.state.status.ovF)).toBe(true);
+    });
+
+    test('rapidOverride is not supported and writes nothing', () => {
+      const { controller, writes } = create();
+
+      controller.command('rapidOverride', 50);
+
+      expect(writes).toEqual([]);
+    });
+  });
+
+  describe('lasertest', () => {
+    test('lasertest:on fires the laser at 0% power in manual mode by default', () => {
+      const { controller, writes } = create();
+
+      controller.command('lasertest:on');
+
+      expect(written(writes)).toEqual(['M3\n', 'fire 0\n']);
+    });
+
+    test('lasertest:on fires, dwells, and turns the laser off when a duration is given', () => {
+      const { controller, writes } = create();
+
+      controller.command('lasertest:on', 50, 1000);
+
+      expect(written(writes)).toEqual(['M3\n', 'fire 50\n', 'G4P1\n', 'fire off\n', 'M5\n']);
+    });
+
+    test('lasertest:off turns the laser off and returns to auto mode', () => {
+      const { controller, writes } = create();
+
+      controller.command('lasertest:off');
+
+      expect(written(writes)).toEqual(['fire off\n', 'M5\n']);
+    });
+  });
+
+  describe('sender workflow', () => {
+    test('gcode:load stores the program plus the dwell line and returns the sender snapshot', () => {
+      const { controller, writes } = create();
+      const callback = jest.fn();
+
+      controller.command('gcode:load', 'gcode-test', 'G0 X1\nG0 X2', callback);
+
+      expect(writes).toEqual([]);
+      expect(callback).toHaveBeenCalledTimes(1);
+      const [err, snapshot] = callback.mock.calls[0];
+      expect(err).toBeNull();
+      expect(snapshot).toMatchObject({
+        name: 'gcode-test',
+        total: 3,
+        sent: 0,
+        received: 0,
+        hold: false,
+      });
+    });
+
+    test('gcode:load accepts the callback in the context position', () => {
+      const { controller } = create();
+      const callback = jest.fn();
+
+      controller.command('gcode:load', 'gcode-test', 'G0 X1', callback);
+
+      const [err, snapshot] = callback.mock.calls[0];
+      expect(err).toBeNull();
+      expect(snapshot).toMatchObject({ name: 'gcode-test', total: 2 });
+    });
+
+    test('gcode:start streams the short program into the controller buffer', () => {
+      const { controller, writes } = create();
+
+      controller.command('gcode:load', 'gcode-test', 'G0 X1\nG0 X2');
+      controller.command('gcode:start');
+
+      expect(written(writes)).toEqual(['G0 X1\n', 'G0 X2\n', 'G4 S0.5\n']);
+    });
+
+    test('gcode:pause suspends the machine', () => {
+      const { controller, writes } = create();
+
+      controller.command('gcode:load', 'gcode-test', 'G0 X1\nG0 X2');
+      controller.command('gcode:start');
+      controller.command('gcode:pause');
+
+      expect(written(writes)).toEqual(['G0 X1\n', 'G0 X2\n', 'G4 S0.5\n', 'suspend\n']);
+    });
+
+    test('gcode:resume resumes the machine after a pause', () => {
+      const { controller, writes } = create();
+
+      controller.command('gcode:load', 'gcode-test', 'G0 X1\nG0 X2');
+      controller.command('gcode:start');
+      controller.command('gcode:pause');
+      controller.command('gcode:resume');
+
+      expect(written(writes)).toEqual(['G0 X1\n', 'G0 X2\n', 'G4 S0.5\n', 'suspend\n', 'resume\n']);
+    });
+
+    test('gcode:resume writes the next line once the buffer has space again', () => {
+      const { controller, writes } = create();
+      const program = Array.from({ length: 30 }, () => 'G0 X1').join('\n');
+
+      controller.command('gcode:load', 'gcode-test', program);
+      controller.command('gcode:start');
+      expect(written(writes)).toHaveLength(19);
+      controller.command('gcode:pause');
+      expect(written(writes)[19]).toBe('suspend\n');
+      controller.command('gcode:resume');
+      expect(written(writes)[20]).toBe('resume\n');
+      expect(written(writes)[21]).toBe('G0 X1\n');
+      expect(written(writes)).toHaveLength(22);
+    });
+
+    test('gcode:stop writes nothing unless the machine is on hold', () => {
+      const { controller, writes } = create();
+
+      controller.command('gcode:load', 'gcode-test', 'G0 X1\nG0 X2');
+      controller.command('gcode:start');
+      controller.command('gcode:pause');
+      controller.command('gcode:stop');
+
+      expect(written(writes)).toEqual(['G0 X1\n', 'G0 X2\n', 'G4 S0.5\n', 'suspend\n']);
+    });
+
+    test('gcode:stop writes resume when the active state is Hold', () => {
+      const { controller, writes } = create();
+
+      controller.command('gcode:load', 'gcode-test', 'G0 X1\nG0 X2');
+      controller.command('gcode:start');
+      controller.command('gcode:pause');
+      controller.state = { status: { activeState: SMOOTHIE_ACTIVE_STATE_HOLD } };
+      controller.command('gcode:stop');
+
+      expect(written(writes)).toEqual(['G0 X1\n', 'G0 X2\n', 'G4 S0.5\n', 'suspend\n', 'resume\n']);
+    });
+
+    test('gcode:unload clears the sender without writing', () => {
+      const { controller, writes } = create();
+
+      controller.command('gcode:load', 'gcode-test', 'G0 X1\nG0 X2');
+      controller.command('gcode:unload');
+
+      expect(writes).toEqual([]);
+      expect(controller.sender.state.name).toBe('');
+      expect(controller.sender.state.total).toBe(0);
+    });
+  });
+
+  describe('deprecated aliases', () => {
+    test.each([
+      ['start', 'gcode:start', (ctl) => {
+        ctl.command('gcode:load', 'gcode-test', 'G0 X1\nG0 X2');
+      }],
+      ['stop', 'gcode:stop', (ctl) => {
+        ctl.command('gcode:load', 'gcode-test', 'G0 X1\nG0 X2');
+        ctl.state = { status: { activeState: SMOOTHIE_ACTIVE_STATE_HOLD } };
+      }],
+      ['pause', 'gcode:pause', (ctl) => {
+        ctl.command('gcode:load', 'gcode-test', 'G0 X1\nG0 X2');
+      }],
+      ['resume', 'gcode:resume', (ctl) => {
+        ctl.command('gcode:load', 'gcode-test', 'G0 X1\nG0 X2');
+        ctl.command('gcode:start');
+        ctl.command('gcode:pause');
+      }],
+    ])('%s produces the same writes as %s', (alias, canonical, prepare) => {
+      const aliasState = create();
+      const canonicalState = create();
+      prepare(aliasState.controller);
+      prepare(canonicalState.controller);
+
+      aliasState.controller.command(alias);
+      canonicalState.controller.command(canonical);
+
+      expect(aliasState.writes.length).toBeGreaterThan(0);
+      expect(written(aliasState.writes)).toEqual(written(canonicalState.writes));
+    });
+  });
+
+  describe('feeder commands', () => {
+    test('gcode feeds lines through the feeder source and filters empty lines', () => {
+      const { controller, writes } = create();
+      const serialEvents = captureSerialWrites(controller);
+
+      controller.command('gcode', 'G0 X1\n\nG0 X2');
+
+      expect(written(writes)).toEqual(['G0 X1\n']);
+
+      pumpFeeder(controller);
+
+      expect(written(writes)).toEqual(['G0 X1\n', 'G0 X2\n']);
+      expect(serialEvents.map((event) => event.context.source)).toEqual([
+        WRITE_SOURCE_FEEDER,
+        WRITE_SOURCE_FEEDER,
+      ]);
+    });
+
+    test('feeder:feed feeds commands like gcode', () => {
+      const { controller, writes } = create();
+
+      controller.command('feeder:feed', 'G0 X1');
+
+      expect(written(writes)).toEqual(['G0 X1\n']);
+    });
+
+    test('feeder:start resumes the feeder and drains the queue', () => {
+      const { controller, writes } = create();
+
+      controller.command('feeder:feed', 'G0 X5\nG0 X6');
+      controller.command('feeder:start');
+
+      expect(written(writes)).toEqual(['G0 X5\n', 'resume\n', 'G0 X6\n']);
+    });
+
+    test('feeder:start does nothing while a program is running', () => {
+      const { controller, writes } = create();
+
+      controller.command('gcode:load', 'gcode-test', 'G0 X1\nG0 X2');
+      controller.command('gcode:start');
+      controller.command('feeder:feed', 'G0 X5');
+      controller.command('feeder:start');
+
+      expect(written(writes)).toEqual(['G0 X1\n', 'G0 X2\n', 'G4 S0.5\n', 'G0 X5\n']);
+    });
+
+    test('feeder:stop drops queued lines', () => {
+      const { controller, writes } = create();
+
+      controller.command('feeder:feed', 'G0 X5\nG0 X6');
+      controller.command('feeder:stop');
+      pumpFeeder(controller);
+
+      expect(written(writes)).toEqual(['G0 X5\n']);
+    });
+  });
+
+  describe('macros and watch directory', () => {
+    const macros = [{ id: 'm1', name: 'Macro One', content: 'G0 X1\nG0 X2' }];
+
+    test('macro:run feeds the macro content through the feeder', () => {
+      const { controller, writes } = create();
+      setConfig({ macros });
+      const callback = jest.fn();
+
+      controller.command('macro:run', 'm1', {}, callback);
+
+      expect(written(writes)).toEqual(['G0 X1\n']);
+
+      pumpFeeder(controller);
+
+      expect(written(writes)).toEqual(['G0 X1\n', 'G0 X2\n']);
+      expect(callback).toHaveBeenCalledWith(null);
+    });
+
+    test('macro:load loads the macro content into the sender', () => {
+      const { controller, writes } = create();
+      setConfig({ macros });
+      const callback = jest.fn();
+
+      controller.command('macro:load', 'm1', {}, callback);
+
+      expect(writes).toEqual([]);
+      expect(callback).toHaveBeenCalledWith(null, expect.objectContaining({
+        name: 'Macro One',
+        total: 3,
+      }));
+    });
+
+    test('missing macros invoke neither the feeder nor the callback', () => {
+      const { controller, writes } = create();
+      setConfig({ macros });
+      const runCallback = jest.fn();
+      const loadCallback = jest.fn();
+
+      controller.command('macro:run', 'missing', {}, runCallback);
+      controller.command('macro:load', 'missing', {}, loadCallback);
+
+      expect(writes).toEqual([]);
+      expect(runCallback).not.toHaveBeenCalled();
+      expect(loadCallback).not.toHaveBeenCalled();
+    });
+
+    test('watchdir:load reads the file through the monitor and loads it', () => {
+      const { controller, writes } = create();
+      jest.spyOn(monitor, 'readFile').mockImplementation((file, callback) => callback(null, 'G0 X1\nG0 X2'));
+      const callback = jest.fn();
+
+      controller.command('watchdir:load', 'watch/x.nc', callback);
+
+      expect(monitor.readFile).toHaveBeenCalledWith('watch/x.nc', expect.any(Function));
+      expect(writes).toEqual([]);
+      expect(callback).toHaveBeenCalledWith(null, expect.objectContaining({
+        name: 'watch/x.nc',
+        total: 3,
+      }));
+    });
+
+    test('watchdir:load forwards monitor read errors to the callback', () => {
+      const { controller, writes } = create();
+      jest.spyOn(monitor, 'readFile').mockImplementation((file, callback) => callback(new Error('read failed')));
+      const callback = jest.fn();
+
+      controller.command('watchdir:load', 'watch/x.nc', callback);
+
+      expect(writes).toEqual([]);
+      const [err] = callback.mock.calls[0];
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toBe('read failed');
+    });
+  });
+
+  describe('tool:change', () => {
+    const runToolChange = ({ policy, overrides = {}, modalUnits = 'G21' }) => {
+      const { controller, writes } = create();
+      setConfig({
+        'tool.toolChangePolicy': policy,
+        'tool.toolChangeX': 0,
+        'tool.toolChangeY': 0,
+        'tool.toolChangeZ': 0,
+        'tool.toolProbeX': 0,
+        'tool.toolProbeY': 0,
+        'tool.toolProbeZ': 0,
+        'tool.toolProbeCommand': 'G38.2',
+        'tool.toolProbeDistance': 1,
+        'tool.toolProbeFeedrate': 10,
+        'tool.touchPlateHeight': 0,
+        ...overrides,
+      });
+      seedModal(controller, { units: modalUnits });
+      controller.command('tool:change');
+      pumpFeeder(controller);
+      return written(writes);
+    };
+
+    const metricToolChangeSequence = (policyLines) => [
+      'G4 S0.5\n',
+      'M5\n',
+      'G90\n',
+      'G53 G0 Z0.000\n',
+      'G53 G0 X0.000 Y0.000\n',
+      'G4 S0.5\n',
+      'M0\n',
+      'G53 G0 X0.000 Y0.000\n',
+      'G53 G0 Z0.000\n',
+      'G4 S0.5\n',
+      ...policyLines,
+      'G53 G0 Z0.000\n',
+      'G53 G0 X0.000 Y0.000\n',
+      'G4 S0.5\n',
+      'M0\n',
+      'G90\n',
+      'G0 X0 Y0\n',
+      'G0 Z0\n',
+      'M5\n',
+      'G4 S5\n',
+    ];
+
+    test.each([
+      ['IGNORE_M6_COMMANDS', TOOL_CHANGE_POLICY_IGNORE_M6_COMMANDS, []],
+      ['SEND_M6_COMMANDS', TOOL_CHANGE_POLICY_SEND_M6_COMMANDS, []],
+      ['MANUAL_TOOL_CHANGE_WCS', TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_WCS, [
+        'G91 G38.2 F10 Z-1\n',
+        'G10 L20 P1 Z0\n',
+      ]],
+      ['MANUAL_TOOL_CHANGE_TLO', TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_TLO, [
+        'G91 G38.2 F10 Z-1\n',
+        'G4 S1\n',
+        'G43.1 Z0\n',
+      ]],
+      ['MANUAL_TOOL_CHANGE_CUSTOM_PROBING', TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_CUSTOM_PROBING, [
+        'G4 P0.5\n',
+        'G30 Z0.1\n',
+      ]],
+    ])('with policy %s writes the exact resolved sequence', (_name, policy, policyLines) => {
+      const overrides = policy === TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_CUSTOM_PROBING
+        ? { 'tool.toolProbeCustomCommands': 'G4 P0.5\nG30 Z0.1' }
+        : {};
+
+      expect(runToolChange({ policy, overrides })).toEqual(metricToolChangeSequence(policyLines));
+    });
+
+    test('converts pinned metric config values to imperial units under G20', () => {
+      expect(runToolChange({
+        policy: TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_WCS,
+        modalUnits: 'G20',
+        overrides: {
+          'tool.toolChangeX': 25.4,
+          'tool.toolChangeY': 25.4,
+          'tool.toolChangeZ': 25.4,
+          'tool.toolProbeDistance': 25.4,
+          'tool.toolProbeFeedrate': 254,
+          'tool.touchPlateHeight': 12.7,
+        },
+      })).toEqual([
+        'G4 S0.5\n',
+        'M5\n',
+        'G90\n',
+        'G53 G0 Z1.0000\n',
+        'G53 G0 X1.0000 Y1.0000\n',
+        'G4 S0.5\n',
+        'M0\n',
+        'G53 G0 X0.0000 Y0.0000\n',
+        'G53 G0 Z0.0000\n',
+        'G4 S0.5\n',
+        'G91 G38.2 F10 Z-1\n',
+        'G10 L20 P1 Z0.5\n',
+        'G53 G0 Z1.0000\n',
+        'G53 G0 X1.0000 Y1.0000\n',
+        'G4 S0.5\n',
+        'M0\n',
+        'G90\n',
+        'G0 X0 Y0\n',
+        'G0 Z0\n',
+        'M5\n',
+        'G4 S5\n',
+      ]);
+    });
+  });
+
+  describe('autolevel', () => {
+    const gridParams = {
+      startX: 0,
+      endX: 10,
+      stepX: 10,
+      startY: 0,
+      endY: 10,
+      stepY: 10,
+      clearanceZ: 5,
+      startZ: 2,
+      endZ: -1,
+      feedrate: 100,
+    };
+
+    test('autolevel:start in test mode probes once at the current position', () => {
+      const { controller, writes } = create();
+
+      controller.command('autolevel:start', { mode: 'test', ...gridParams });
+
+      expect(written(writes)).toEqual(['G90\n']);
+
+      pumpFeeder(controller);
+
+      expect(written(writes)).toEqual([
+        'G90\n',
+        'G0 Z5\n',
+        'G0 Z2\n',
+        'G38.2 Z-1 F100\n',
+        'G0 Z5\n',
+      ]);
+    });
+
+    test('autolevel:start in full mode resets probe state and probes the grid', () => {
+      const { controller, writes } = create();
+
+      controller.command('autolevel:start', gridParams);
+
+      expect(written(writes)).toEqual(['G90\n']);
+
+      pumpFeeder(controller);
+
+      expect(written(writes)).toEqual([
+        'G90\n', 'G0 Z5\n', 'G0 X0 Y0\n', 'G0 Z2\n', 'G38.2 Z-1 F50\n', 'G0 Z5\n',
+        'G90\n', 'G0 Z5\n', 'G0 X10 Y0\n', 'G0 Z2\n', 'G38.2 Z-1 F100\n', 'G0 Z5\n',
+        'G90\n', 'G0 Z5\n', 'G0 X0 Y10\n', 'G0 Z2\n', 'G38.2 Z-1 F100\n', 'G0 Z5\n',
+        'G90\n', 'G0 Z5\n', 'G0 X10 Y10\n', 'G0 Z2\n', 'G38.2 Z-1 F100\n', 'G0 Z5\n',
+      ]);
+      expect(controller.probeState.probePoints).toEqual([
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 0, y: 10 },
+        { x: 10, y: 10 },
+      ]);
+      expect(controller.probeState.config).toEqual(gridParams);
+      expect(controller.probeState.probedPositions).toEqual([]);
+      expect(controller.probeState.minZ).toBeNull();
+      expect(controller.probeState.maxZ).toBeNull();
+    });
+
+    test('autolevel:stop resets the connection and clears probe state', () => {
+      const { controller, writes } = create();
+      controller.probeState = {
+        probedPositions: [{ x: 1, y: 2, z: 3 }],
+        probePoints: [{ x: 0, y: 0 }],
+        minZ: 3,
+        maxZ: 3,
+        config: gridParams,
+      };
+
+      controller.command('autolevel:stop');
+
+      expect(written(writes)).toEqual(['\x18']);
+      expect(controller.probeState).toEqual({
+        probedPositions: [],
+        probePoints: [],
+        minZ: null,
+        maxZ: null,
+        config: null,
+      });
+    });
+
+    test('autolevel:getProbeState returns the live probe state', () => {
+      const { controller } = create();
+      const callback = jest.fn();
+
+      controller.command('autolevel:getProbeState', null, callback);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      const [, payload] = callback.mock.calls[0];
+      expect(payload.state).toBe(controller.probeState);
+    });
+
+    test('autolevel:loadFromFile loads 9-column probe rows', async () => {
+      const { controller } = create();
+      const filepath = path.join(os.tmpdir(), `cncjs-smoothie-probes-${process.pid}-${Date.now()}.txt`);
+      tempFiles.push(filepath);
+      await fsp.writeFile(filepath, '0 0 -1.5 0 0 0 0 0 0\n10 0 -1.2 0 0 0 0 0 0\n', 'utf8');
+      const callback = jest.fn();
+
+      controller.command('autolevel:loadFromFile', filepath, callback);
+      await waitForCallback(callback);
+
+      expect(callback).toHaveBeenCalledWith(null, expect.objectContaining({ success: true }));
+      expect(controller.probeState.probedPositions).toEqual([
+        { x: 0, y: 0, z: -1.5 },
+        { x: 10, y: 0, z: -1.2 },
+      ]);
+      expect(controller.probeState.minZ).toBe(-1.5);
+      expect(controller.probeState.maxZ).toBe(-1.2);
+    });
+
+    test('autolevel:loadFromFile reports the read error message for a missing file', async () => {
+      const { controller } = create();
+      const callback = jest.fn();
+
+      controller.command('autolevel:loadFromFile', path.join(os.tmpdir(), 'cncjs-smoothie-missing-probe-file.txt'), callback);
+      await waitForCallback(callback);
+
+      const [err, payload] = callback.mock.calls[0];
+      expect(typeof err).toBe('string');
+      expect(payload).toEqual({ success: false, state: null });
+    });
+
+    test('autolevel:saveToFile writes 9-column rows and reports the filepath', async () => {
+      const { controller } = create();
+      controller.probeState.probedPositions = [
+        { x: 0, y: 0, z: -1.5 },
+        { x: 10, y: 0, z: -1.2 },
+      ];
+      const filepath = path.join(os.tmpdir(), `cncjs-smoothie-save-${process.pid}-${Date.now()}.txt`);
+      tempFiles.push(filepath);
+      const callback = jest.fn();
+
+      controller.command('autolevel:saveToFile', filepath, callback);
+      await waitForCallback(callback);
+
+      expect(callback).toHaveBeenCalledWith(null, { success: true, filepath });
+      await expect(fsp.readFile(filepath, 'utf8')).resolves.toBe(
+        '0 0 -1.5 0 0 0 0 0 0\n10 0 -1.2 0 0 0 0 0 0'
+      );
+    });
+
+    test('autolevel:applyProbeCompensation returns the compensated G-code from the autolevel lib', () => {
+      const { controller } = create();
+      const gcode = 'G0 X0 Y0\nG1 Z-1 F100';
+      const probeData = [
+        { x: 0, y: 0, z: 0 },
+        { x: 10, y: 0, z: 0 },
+        { x: 0, y: 10, z: 0 },
+        { x: 10, y: 10, z: 0 },
+      ];
+      const callback = jest.fn();
+
+      controller.command('autolevel:applyProbeCompensation', { gcode, probeData }, callback);
+
+      expect(callback).toHaveBeenCalledWith(null, {
+        compensatedGcode: autolevel.applyProbeCompensation(gcode, probeData),
+      });
+    });
+  });
+
+  describe('negative tests', () => {
+    test('unknown command writes nothing', () => {
+      const { controller, writes } = create();
+
+      controller.command('nonexistent');
+
+      expect(writes).toEqual([]);
+    });
+
+    test('commands write nothing while the connection is closed', () => {
+      const { controller, writes } = create();
+      controller.connection.isOpen = false;
+
+      controller.command('feedhold');
+      controller.command('statusreport');
+      controller.command('homing');
+      controller.command('gcode', 'G0 X1');
+
+      expect(writes).toEqual([]);
+    });
+
+    test('gcode:load cannot reach the invalid-input error path because the dwell concatenation masks it', () => {
+      const { controller } = create();
+      const callback = jest.fn();
+
+      controller.command('gcode:load', 'empty', '', callback);
+
+      const [err, snapshot] = callback.mock.calls[0];
+      expect(err).toBeNull();
+      expect(snapshot).toMatchObject({ name: 'empty', total: 1 });
+    });
+  });
+});

--- a/src/server/controllers/TinyG/__tests__/TinyGController.test.js
+++ b/src/server/controllers/TinyG/__tests__/TinyGController.test.js
@@ -1,0 +1,894 @@
+/* eslint-env jest */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import TinyGController from '../TinyGController';
+import config from '../../../services/configstore';
+import monitor from '../../../services/monitor';
+import { WORKFLOW_STATE_IDLE, WORKFLOW_STATE_PAUSED, WORKFLOW_STATE_RUNNING } from '../../../lib/Workflow';
+import {
+  TOOL_CHANGE_POLICY_IGNORE_M6_COMMANDS,
+  TOOL_CHANGE_POLICY_SEND_M6_COMMANDS,
+  TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_WCS,
+  TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_TLO,
+  TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_CUSTOM_PROBING,
+  WRITE_SOURCE_CLIENT,
+  WRITE_SOURCE_FEEDER,
+} from '../../constants';
+import { createController } from '../../__tests__/helpers/createController';
+
+let controllers = [];
+let configSpy = null;
+const tempFiles = [];
+
+afterEach(() => {
+  controllers.forEach((controller) => controller.destroy());
+  controllers = [];
+  if (configSpy) {
+    configSpy.mockRestore();
+    configSpy = null;
+  }
+  tempFiles.forEach((file) => {
+    if (fs.existsSync(file)) {
+      fs.unlinkSync(file);
+    }
+  });
+  tempFiles.length = 0;
+});
+
+const setupController = (configOverrides = {}) => {
+  configSpy = jest.spyOn(config, 'get').mockImplementation((key, defaultValue) => {
+    if (Object.prototype.hasOwnProperty.call(configOverrides, key)) {
+      return configOverrides[key];
+    }
+    return defaultValue;
+  });
+
+  const { controller, writes } = createController(TinyGController);
+
+  // TinyG connection.write drops the context argument, so write sources are
+  // observed through the socket-facing 'serialport:write' event instead.
+  const events = [];
+  controller.sockets.test = { emit: (event, ...args) => events.push({ event, args }) };
+  controllers.push(controller);
+
+  return { controller, writes, events };
+};
+
+const data = (writes) => writes.map((entry) => entry.data);
+
+const sourceOf = (events, text) => events
+  .filter((entry) => entry.event === 'serialport:write' && entry.args[0] === text)
+  .map((entry) => entry.args[1].source);
+
+// The feeder writes one line per machine acknowledgement and parks on M0/%wait
+// holds; unholding between next() calls replays the full queue synchronously.
+const drainFeeder = (controller) => {
+  while (controller.feeder.size() > 0) {
+    if (controller.feeder.state.hold) {
+      controller.feeder.unhold();
+    }
+    controller.feeder.next();
+  }
+};
+
+const seedModal = (controller, modal) => {
+  controller.runner.state = {
+    ...controller.runner.state,
+    sr: {
+      ...controller.runner.state.sr,
+      modal: {
+        ...controller.runner.state.sr.modal,
+        ...modal,
+      },
+    },
+  };
+};
+
+const captureConsoleOutput = (fn) => {
+  const chunks = [];
+  const stdoutSpy = jest.spyOn(console._stdout || process.stdout, 'write').mockImplementation((chunk) => {
+    chunks.push(String(chunk));
+    return true;
+  });
+  const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+    chunks.push(String(chunk));
+    return true;
+  });
+  try {
+    fn();
+  } finally {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  }
+  return chunks.join('');
+};
+
+const tempFile = (name) => {
+  const file = path.join(os.tmpdir(), name);
+  tempFiles.push(file);
+  return file;
+};
+
+const toolChangeWrites = ({ changeZ, changeXY, probeXY, probeZ, policyLines }) => [
+  'G4 P0.5',
+  'M5',
+  'G90',
+  changeZ,
+  changeXY,
+  'G4 P0.5',
+  'M0',
+  probeXY,
+  probeZ,
+  'G4 P0.5',
+  ...policyLines,
+  changeZ,
+  changeXY,
+  'G4 P0.5',
+  'M0',
+  'G90',
+  'G0 X0 Y0',
+  'G0 Z0',
+  'M5',
+  'G4 P5',
+].map((line) => line + '\n');
+
+describe('TinyGController', () => {
+  describe('command handlers', () => {
+    test.each([
+      ['feedhold', ['!\n', '{"qr":""}\n']],
+      ['cyclestart', ['~\n', '{"qr":""}\n']],
+      ['statusreport', ['{"sr":null}\n']],
+      ['homing', ['G28.2 X0 Y0 Z0\n']],
+      ['sleep', []],
+      ['unlock', ['{clear:null}\n']],
+      ['jogCancel', ['!\n', '%\n']],
+    ])('command %s writes %j', (cmd, expected) => {
+      const { controller, writes } = setupController();
+
+      controller.command(cmd);
+
+      expect(data(writes)).toEqual(expected);
+    });
+
+    test('feedhold and cyclestart write as the client', () => {
+      const { controller, writes, events } = setupController();
+
+      controller.command('feedhold');
+      controller.command('cyclestart');
+
+      expect(sourceOf(events, '!\n')).toEqual([WRITE_SOURCE_CLIENT]);
+      expect(sourceOf(events, '{"qr":""}\n')).toEqual([WRITE_SOURCE_CLIENT, WRITE_SOURCE_CLIENT]);
+      expect(sourceOf(events, '~\n')).toEqual([WRITE_SOURCE_CLIENT]);
+      expect(writes).toHaveLength(4);
+    });
+
+    test('reset writes a bare control character and clears the feeder', () => {
+      const { controller, writes, events } = setupController();
+
+      controller.command('feeder:feed', ['G21', 'G90']);
+      controller.command('reset');
+
+      expect(data(writes)).toEqual(['G21\n', '\x18']);
+      expect(sourceOf(events, '\x18')).toEqual([WRITE_SOURCE_CLIENT]);
+      expect(controller.feeder.size()).toBe(0);
+      expect(controller.workflow.state).toBe(WORKFLOW_STATE_IDLE);
+    });
+
+    describe('feedOverride', () => {
+      test.each([
+        [0, '{mfo:1}'],
+        [150, '{mfo:2}'],
+        [-96, '{mfo:0.05}'],
+        [10, '{mfo:1.1}'],
+      ])('feedOverride %i writes %s via the feeder', (value, expected) => {
+        const { controller, writes, events } = setupController();
+        controller.runner.settings.mfo = 1;
+
+        controller.command('feedOverride', value);
+
+        expect(data(writes)).toEqual([expected + '\n']);
+        expect(sourceOf(events, expected + '\n')).toEqual([WRITE_SOURCE_FEEDER]);
+      });
+    });
+
+    describe('spindleOverride', () => {
+      test.each([
+        [0, '{sso:1}'],
+        [150, '{sso:2}'],
+        [-96, '{sso:0.05}'],
+        [10, '{sso:1.1}'],
+      ])('spindleOverride %i writes %s via the feeder', (value, expected) => {
+        const { controller, writes } = setupController();
+        controller.runner.settings.sso = 1;
+
+        controller.command('spindleOverride', value);
+
+        expect(data(writes)).toEqual([expected + '\n']);
+      });
+    });
+
+    describe('rapidOverride', () => {
+      test.each([
+        [0, '{mto:1}'],
+        [100, '{mto:1}'],
+        [50, '{mto:0.5}'],
+        [25, '{mto:0.25}'],
+      ])('rapidOverride %i writes %s via the feeder', (value, expected) => {
+        const { controller, writes } = setupController();
+
+        controller.command('rapidOverride', value);
+
+        expect(data(writes)).toEqual([expected + '\n']);
+      });
+
+      test('rapidOverride ignores unsupported values', () => {
+        const { controller, writes } = setupController();
+
+        controller.command('rapidOverride', 75);
+
+        expect(writes).toEqual([]);
+      });
+    });
+
+    describe('energizeMotors', () => {
+      test('energizeMotors:on without a motor timeout writes nothing', () => {
+        const { controller, writes } = setupController();
+
+        controller.command('energizeMotors:on');
+
+        expect(writes).toEqual([]);
+        expect(controller.timer.energizeMotors).toBeNull();
+      });
+
+      test('energizeMotors:on energizes motors once and arms the timer', () => {
+        const { controller, writes } = setupController();
+        controller.state.mt = 1;
+
+        controller.command('energizeMotors:on');
+        controller.command('energizeMotors:on');
+
+        expect(data(writes)).toEqual(['{me:0}\n', '{pwr:n}\n']);
+        expect(controller.timer.energizeMotors).not.toBeNull();
+      });
+
+      test('energizeMotors:off de-energizes motors and stops the timer', () => {
+        const { controller, writes } = setupController();
+        controller.state.mt = 1;
+
+        controller.command('energizeMotors:on');
+        controller.command('energizeMotors:off');
+
+        expect(data(writes)).toEqual(['{me:0}\n', '{pwr:n}\n', '{md:0}\n', '{pwr:n}\n']);
+        expect(controller.timer.energizeMotors).toBeNull();
+      });
+    });
+
+    describe('lasertest', () => {
+      test('lasertest:on with defaults fires the laser at zero power', () => {
+        const { controller, writes } = setupController();
+
+        controller.command('lasertest:on');
+
+        expect(data(writes)).toEqual(['M3S0\n']);
+      });
+
+      test('lasertest:on with a duration adds dwell and shutdown lines', () => {
+        const { controller, writes } = setupController();
+
+        controller.command('lasertest:on', 50, 250, 2000);
+        drainFeeder(controller);
+
+        expect(data(writes)).toEqual(['M3S1000\n', 'G4P0.25\n', 'M5S0\n']);
+      });
+
+      test('lasertest:off shuts the laser down', () => {
+        const { controller, writes } = setupController();
+
+        controller.command('lasertest:off');
+
+        expect(data(writes)).toEqual(['M5S0\n']);
+      });
+    });
+  });
+
+  describe('gcode and feeder commands', () => {
+    test('gcode feeds non-blank lines through the feeder with its context', () => {
+      const { controller, writes, events } = setupController();
+
+      controller.command('gcode', 'G21\n\n  \nG90', { myContext: true });
+      expect(data(writes)).toEqual(['G21\n']);
+
+      drainFeeder(controller);
+      expect(data(writes)).toEqual(['G21\n', 'G90\n']);
+
+      const [event] = events.filter((entry) => entry.event === 'serialport:write' && entry.args[0] === 'G21\n');
+      expect(event.args[1]).toMatchObject({ myContext: true, source: WRITE_SOURCE_FEEDER });
+    });
+
+    test('feeder:feed delegates to the gcode handler', () => {
+      const { controller, writes } = setupController();
+
+      controller.command('feeder:feed', 'G0 X0');
+
+      expect(data(writes)).toEqual(['G0 X0\n']);
+    });
+
+    test('feeder:start cycles the machine and drains the first queued line', () => {
+      const { controller, writes, events } = setupController();
+
+      controller.command('feeder:feed', ['G0 X0', 'G0 X1']);
+      controller.command('feeder:start');
+
+      expect(data(writes)).toEqual(['G0 X0\n', '~\n', '{"qr":""}\n', 'G0 X1\n']);
+      expect(sourceOf(events, '~\n')).toEqual([WRITE_SOURCE_CLIENT]);
+      expect(sourceOf(events, 'G0 X1\n')).toEqual([WRITE_SOURCE_FEEDER]);
+    });
+
+    test('feeder:start is a no-op while a program is running', () => {
+      const { controller, writes } = setupController();
+
+      controller.command('gcode:start');
+      controller.command('feeder:start');
+
+      expect(writes).toEqual([]);
+    });
+
+    test('feeder:stop clears the queue without writing', () => {
+      const { controller, writes } = setupController();
+
+      controller.command('feeder:feed', ['G0 X0', 'G0 X1']);
+      controller.command('feeder:stop');
+      drainFeeder(controller);
+
+      expect(data(writes)).toEqual(['G0 X0\n']);
+      expect(controller.feeder.size()).toBe(0);
+    });
+  });
+
+  describe('sender workflow', () => {
+    test('gcode:load stores the program plus a planner dwell and reports sender state', () => {
+      const { controller, writes, events } = setupController();
+      const callback = jest.fn();
+
+      controller.command('gcode:load', 'test.nc', 'G21\nG90', callback);
+
+      expect(callback).toHaveBeenCalledWith(null, expect.objectContaining({ name: 'test.nc', total: 3 }));
+      expect(controller.sender.state.gcode).toBe('G21\nG90\n%wait ; Wait for the planner to empty');
+      expect(controller.workflow.state).toBe(WORKFLOW_STATE_IDLE);
+      expect(writes).toEqual([]);
+      expect(events.filter((entry) => entry.event === 'gcode:load')).toHaveLength(1);
+    });
+
+    test('gcode:load pads blank and non-string programs with the planner dwell instead of failing', () => {
+      const runScenario = (gcode) => {
+        const { controller, writes } = setupController();
+        const callback = jest.fn();
+
+        controller.command('gcode:load', 'test.nc', gcode, callback);
+
+        return { callback, writes };
+      };
+
+      // The handler appends the '%wait' dwell before Sender.load, so the
+      // "Invalid G-code" error branch is unreachable for these inputs.
+      const blank = runScenario('');
+      expect(blank.callback).toHaveBeenCalledWith(null, expect.objectContaining({ name: 'test.nc', total: 1 }));
+      expect(blank.writes).toEqual([]);
+
+      const nonString = runScenario(undefined);
+      expect(nonString.callback).toHaveBeenCalledWith(null, expect.objectContaining({ name: 'test.nc', total: 2 }));
+      expect(nonString.writes).toEqual([]);
+    });
+
+    test('gcode:unload clears the sender without writing', () => {
+      const { controller, writes } = setupController();
+
+      controller.command('gcode:load', 'test.nc', 'G21\nG90');
+      controller.command('gcode:unload');
+
+      expect(data(writes)).toEqual([]);
+      expect(controller.sender.state.gcode).toBe('');
+      expect(controller.sender.state.name).toBe('');
+      expect(controller.workflow.state).toBe(WORKFLOW_STATE_IDLE);
+    });
+
+    test('gcode:start sends the first program line with an N-prefixed line number', () => {
+      const { controller, writes } = setupController();
+
+      controller.command('gcode:load', 'test.nc', 'G21\nG90');
+      controller.command('gcode:start');
+
+      expect(data(writes)).toEqual(['N1G21\n']);
+      expect(controller.workflow.state).toBe(WORKFLOW_STATE_RUNNING);
+      expect(controller.sender.state.sent).toBe(1);
+    });
+
+    test('gcode:pause feedholds and reports the queue', () => {
+      const { controller, writes } = setupController();
+
+      controller.command('gcode:load', 'test.nc', 'G21\nG90');
+      controller.command('gcode:start');
+      controller.command('gcode:pause');
+
+      expect(data(writes)).toEqual(['N1G21\n', '!\n', '{"qr":""}\n']);
+      expect(controller.workflow.state).toBe(WORKFLOW_STATE_PAUSED);
+      expect(controller.sender.state.hold).toBe(true);
+    });
+
+    test('gcode:resume resumes the sender before reporting the queue', () => {
+      const { controller, writes } = setupController();
+
+      controller.command('gcode:load', 'test.nc', 'G21\nG90');
+      controller.command('gcode:start');
+      controller.command('gcode:pause');
+      controller.command('gcode:resume');
+
+      expect(data(writes)).toEqual(['N1G21\n', '!\n', '{"qr":""}\n', '~\n', 'N2G90\n', '{"qr":""}\n']);
+      expect(controller.workflow.state).toBe(WORKFLOW_STATE_RUNNING);
+      expect(controller.sender.state.hold).toBe(false);
+    });
+
+    test('gcode:stop without force only reports the queue', () => {
+      const { controller, writes } = setupController();
+
+      controller.command('gcode:load', 'test.nc', 'G21\nG90');
+      controller.command('gcode:start');
+      controller.command('gcode:stop');
+
+      expect(data(writes)).toEqual(['N1G21\n', '{"qr":""}\n']);
+      expect(controller.workflow.state).toBe(WORKFLOW_STATE_IDLE);
+    });
+
+    test.each([
+      [undefined, ['!\n', '%\n', 'M30\n', '{"qr":""}\n']],
+      [100.04, ['\x04\n', 'M30\n', '{"qr":""}\n']],
+      [101.02, ['\x04\n', '{"qr":""}\n']],
+    ])('gcode:stop with force and firmware build %p kills the job accordingly', (fb, expected) => {
+      const { controller, writes } = setupController();
+
+      controller.command('gcode:load', 'test.nc', 'G21\nG90');
+      if (fb !== undefined) {
+        controller.settings.fb = fb;
+      }
+      controller.command('gcode:stop', { force: true });
+
+      expect(data(writes)).toEqual(expected);
+    });
+
+    test.each([
+      ['start', 'gcode:start'],
+      ['stop', 'gcode:stop'],
+      ['pause', 'gcode:pause'],
+      ['resume', 'gcode:resume'],
+    ])('deprecated alias %s writes identically to %s', (alias, canonical) => {
+      const runScenario = (cmd) => {
+        const { controller, writes } = setupController();
+        controller.command('gcode:load', 'test.nc', 'G21\nG90');
+        controller.command(cmd);
+        return data(writes);
+      };
+
+      expect(runScenario(alias)).toEqual(runScenario(canonical));
+    });
+
+    test('deprecated aliases log a deprecation warning', () => {
+      const output = captureConsoleOutput(() => {
+        const { controller } = setupController();
+        controller.command('start');
+      });
+
+      expect(output).toContain('is deprecated');
+    });
+  });
+
+  describe('macros and watchdir', () => {
+    const macros = [{ id: 'm1', name: 'box.nc', content: 'G21\nG90' }];
+
+    test('macro:run feeds the macro content', () => {
+      const { controller, writes } = setupController({ macros });
+      const callback = jest.fn();
+
+      controller.command('macro:run', 'm1', {}, callback);
+      drainFeeder(controller);
+
+      expect(callback).toHaveBeenCalledWith(null);
+      expect(data(writes)).toEqual(['G21\n', 'G90\n']);
+    });
+
+    test('macro:run without a matching macro writes nothing and skips the callback', () => {
+      const { controller, writes } = setupController({ macros });
+      const callback = jest.fn();
+
+      controller.command('macro:run', 'missing', callback);
+
+      expect(callback).not.toHaveBeenCalled();
+      expect(writes).toEqual([]);
+    });
+
+    test('macro:load loads the macro into the sender', () => {
+      const { controller, writes } = setupController({ macros });
+      const callback = jest.fn();
+
+      controller.command('macro:load', 'm1', callback);
+
+      expect(callback).toHaveBeenCalledWith(null, expect.objectContaining({ name: 'box.nc', total: 3 }));
+      expect(controller.sender.state.gcode).toBe('G21\nG90\n%wait ; Wait for the planner to empty');
+      expect(writes).toEqual([]);
+    });
+
+    test('macro:load without a matching macro skips the callback', () => {
+      const { controller } = setupController({ macros });
+      const callback = jest.fn();
+
+      controller.command('macro:load', 'missing', callback);
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    test('watchdir:load loads the monitored file into the sender', () => {
+      const { controller, writes } = setupController();
+      const readFileSpy = jest.spyOn(monitor, 'readFile').mockImplementation((file, callback) => callback(null, 'G21\nG90'));
+      const callback = jest.fn();
+
+      controller.command('watchdir:load', 'part.nc', callback);
+
+      expect(readFileSpy).toHaveBeenCalledWith('part.nc', expect.any(Function));
+      expect(callback).toHaveBeenCalledWith(null, expect.objectContaining({ name: 'part.nc', total: 3 }));
+      expect(controller.sender.state.gcode).toBe('G21\nG90\n%wait ; Wait for the planner to empty');
+      expect(writes).toEqual([]);
+      readFileSpy.mockRestore();
+    });
+
+    test('watchdir:load forwards read errors to the callback', () => {
+      const { controller } = setupController();
+      const readFileSpy = jest.spyOn(monitor, 'readFile').mockImplementation((file, callback) => callback(new Error('boom')));
+      const callback = jest.fn();
+
+      controller.command('watchdir:load', 'part.nc', callback);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback.mock.calls[0][0].message).toBe('boom');
+      readFileSpy.mockRestore();
+    });
+  });
+
+  describe('tool:change', () => {
+    const metricPins = {
+      'tool.toolChangeX': 0,
+      'tool.toolChangeY': 0,
+      'tool.toolChangeZ': 0,
+      'tool.toolProbeX': 0,
+      'tool.toolProbeY': 0,
+      'tool.toolProbeZ': 0,
+      'tool.toolProbeCommand': 'G38.2',
+      'tool.toolProbeDistance': 1,
+      'tool.toolProbeFeedrate': 10,
+      'tool.touchPlateHeight': 0,
+    };
+
+    test.each([
+      [TOOL_CHANGE_POLICY_IGNORE_M6_COMMANDS, 'ignore M6 commands'],
+      [TOOL_CHANGE_POLICY_SEND_M6_COMMANDS, 'send M6 commands'],
+    ])('metric sequence with policy %i (%s)', (policy) => {
+      const { controller, writes } = setupController({
+        ...metricPins,
+        'tool.toolChangePolicy': policy,
+      });
+      seedModal(controller, { spindle: 'M5', wcs: 'G54' });
+
+      controller.command('tool:change');
+      drainFeeder(controller);
+
+      expect(data(writes)).toEqual(toolChangeWrites({
+        changeZ: 'G53 G0 Z0.000',
+        changeXY: 'G53 G0 X0.000 Y0.000',
+        probeXY: 'G53 G0 X0.000 Y0.000',
+        probeZ: 'G53 G0 Z0.000',
+        policyLines: [],
+      }));
+    });
+
+    test('metric sequence with the manual tool change WCS policy probes and offsets the WCS', () => {
+      const { controller, writes } = setupController({
+        ...metricPins,
+        'tool.toolChangePolicy': TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_WCS,
+      });
+      seedModal(controller, { spindle: 'M5', wcs: 'G54' });
+
+      controller.command('tool:change');
+      drainFeeder(controller);
+
+      expect(data(writes)).toEqual(toolChangeWrites({
+        changeZ: 'G53 G0 Z0.000',
+        changeXY: 'G53 G0 X0.000 Y0.000',
+        probeXY: 'G53 G0 X0.000 Y0.000',
+        probeZ: 'G53 G0 Z0.000',
+        policyLines: ['G91 G38.2 F10 Z-1', 'G10 L20 P1 Z0'],
+      }));
+    });
+
+    test('metric sequence with the manual tool change TLO policy probes and sets a tool offset', () => {
+      const { controller, writes } = setupController({
+        ...metricPins,
+        'tool.toolChangePolicy': TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_TLO,
+      });
+      seedModal(controller, { spindle: 'M5', wcs: 'G54' });
+
+      controller.command('tool:change');
+      drainFeeder(controller);
+
+      expect(data(writes)).toEqual(toolChangeWrites({
+        changeZ: 'G53 G0 Z0.000',
+        changeXY: 'G53 G0 X0.000 Y0.000',
+        probeXY: 'G53 G0 X0.000 Y0.000',
+        probeZ: 'G53 G0 Z0.000',
+        policyLines: ['G91 G38.2 F10 Z-1', 'G4 P1', '{tofz:0}'],
+      }));
+    });
+
+    test('metric sequence with the custom probing policy inserts the configured commands', () => {
+      const { controller, writes } = setupController({
+        ...metricPins,
+        'tool.toolChangePolicy': TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_CUSTOM_PROBING,
+        'tool.toolProbeCustomCommands': 'G38.2 Z-5 F25\nG92 Z0',
+      });
+      seedModal(controller, { spindle: 'M5', wcs: 'G54' });
+
+      controller.command('tool:change');
+      drainFeeder(controller);
+
+      expect(data(writes)).toEqual(toolChangeWrites({
+        changeZ: 'G53 G0 Z0.000',
+        changeXY: 'G53 G0 X0.000 Y0.000',
+        probeXY: 'G53 G0 X0.000 Y0.000',
+        probeZ: 'G53 G0 Z0.000',
+        policyLines: ['G38.2 Z-5 F25', 'G92 Z0'],
+      }));
+    });
+
+    test('imperial units convert pinned millimeter positions and values', () => {
+      const { controller, writes } = setupController({
+        'tool.toolChangePolicy': TOOL_CHANGE_POLICY_MANUAL_TOOL_CHANGE_WCS,
+        'tool.toolChangeX': 25.4,
+        'tool.toolChangeY': 0,
+        'tool.toolChangeZ': 25.4,
+        'tool.toolProbeX': 0,
+        'tool.toolProbeY': 0,
+        'tool.toolProbeZ': 0,
+        'tool.toolProbeCommand': 'G38.2',
+        'tool.toolProbeDistance': 25.4,
+        'tool.toolProbeFeedrate': 254,
+        'tool.touchPlateHeight': 25.4,
+      });
+      seedModal(controller, { spindle: 'M5', wcs: 'G54', units: 'G20' });
+
+      controller.command('tool:change');
+      drainFeeder(controller);
+
+      expect(data(writes)).toEqual(toolChangeWrites({
+        changeZ: 'G53 G0 Z1.0000',
+        changeXY: 'G53 G0 X1.0000 Y0.0000',
+        probeXY: 'G53 G0 X0.0000 Y0.0000',
+        probeZ: 'G53 G0 Z0.0000',
+        policyLines: ['G91 G38.2 F10 Z-1', 'G10 L20 P1 Z1'],
+      }));
+    });
+  });
+
+  describe('autolevel', () => {
+    test('autolevel:start in test mode emits the exact five-line probe sequence', () => {
+      const { controller, writes } = setupController();
+
+      controller.command('autolevel:start', {
+        mode: 'test',
+        clearanceZ: 5,
+        startZ: 1,
+        endZ: -1,
+        feedrate: 100,
+      });
+      drainFeeder(controller);
+
+      expect(data(writes)).toEqual([
+        'G90\n',
+        'G0 Z5\n',
+        'G0 Z1\n',
+        'G38.2 Z-1 F100\n',
+        'G0 Z5\n',
+      ]);
+    });
+
+    test('autolevel:start in full mode probes a 2x2 grid in row-major order', () => {
+      const params = {
+        mode: 'full',
+        startX: 0,
+        endX: 10,
+        stepX: 10,
+        startY: 0,
+        endY: 10,
+        stepY: 10,
+        clearanceZ: 5,
+        startZ: 1,
+        endZ: -1,
+        feedrate: 100,
+      };
+      const { controller, writes } = setupController();
+
+      controller.command('autolevel:start', params);
+      drainFeeder(controller);
+
+      const point = (x, y, index) => [
+        'G90\n',
+        'G0 Z5\n',
+        `G0 X${x} Y${y}\n`,
+        'G0 Z1\n',
+        `G38.2 Z-1 F${index === 0 ? 50 : 100}\n`,
+        'G0 Z5\n',
+      ];
+      expect(data(writes)).toEqual([
+        ...point(0, 0, 0),
+        ...point(10, 0, 1),
+        ...point(0, 10, 2),
+        ...point(10, 10, 3),
+      ]);
+      expect(controller.probeState.probePoints).toEqual([
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 0, y: 10 },
+        { x: 10, y: 10 },
+      ]);
+      expect(controller.probeState.probedPositions).toEqual([]);
+      expect(controller.probeState.config).toEqual({
+        startX: 0,
+        endX: 10,
+        stepX: 10,
+        startY: 0,
+        endY: 10,
+        stepY: 10,
+        clearanceZ: 5,
+        startZ: 1,
+        endZ: -1,
+        feedrate: 100,
+      });
+    });
+
+    test('autolevel:stop resets the board and clears the probe state', () => {
+      const { controller, writes } = setupController();
+
+      controller.command('autolevel:start', {
+        mode: 'full',
+        startX: 0,
+        endX: 10,
+        stepX: 10,
+        startY: 0,
+        endY: 10,
+        stepY: 10,
+        clearanceZ: 5,
+        startZ: 1,
+        endZ: -1,
+        feedrate: 100,
+      });
+      controller.command('autolevel:stop');
+
+      expect(data(writes)).toEqual(['G90\n', '\x18']);
+      expect(controller.feeder.size()).toBe(0);
+      expect(controller.probeState).toEqual({
+        probedPositions: [],
+        probePoints: [],
+        minZ: null,
+        maxZ: null,
+        config: null,
+      });
+    });
+
+    test('autolevel:getProbeState reports the current probe state', () => {
+      const { controller } = setupController();
+      controller.probeState.probedPositions = [{ x: 1, y: 2, z: 3 }];
+      const callback = jest.fn();
+
+      controller.command('autolevel:getProbeState', null, callback);
+
+      expect(callback).toHaveBeenCalledWith(null, { state: controller.probeState });
+    });
+
+    test('autolevel:loadFromFile parses nine-column probe rows', async () => {
+      const { controller } = setupController();
+      const file = tempFile('cncjs-tinyg-probe-data.txt');
+      fs.writeFileSync(file, '0 0 1 0 0 0 0 0 0\n10 0 -2 0 0 0 0 0 0\n', 'utf8');
+      const callback = jest.fn();
+
+      await new Promise((resolve) => {
+        controller.command('autolevel:loadFromFile', file, (...args) => {
+          callback(...args);
+          resolve();
+        });
+      });
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      const [err, payload] = callback.mock.calls[0];
+      expect(err).toBeNull();
+      expect(payload.success).toBe(true);
+      expect(controller.probeState.probedPositions).toEqual([
+        { x: 0, y: 0, z: 1 },
+        { x: 10, y: 0, z: -2 },
+      ]);
+      expect(controller.probeState.minZ).toBe(-2);
+      expect(controller.probeState.maxZ).toBe(1);
+    });
+
+    test('autolevel:loadFromFile reports missing files via the callback', async () => {
+      const { controller } = setupController();
+      const file = tempFile('cncjs-tinyg-missing-probe-data.txt');
+      const callback = jest.fn();
+
+      await new Promise((resolve) => {
+        controller.command('autolevel:loadFromFile', file, (...args) => {
+          callback(...args);
+          resolve();
+        });
+      });
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      const [err, payload] = callback.mock.calls[0];
+      expect(err).toContain('ENOENT');
+      expect(payload).toEqual({ success: false, state: null });
+    });
+
+    test('autolevel:saveToFile writes exactly nine columns per row', async () => {
+      const { controller } = setupController();
+      controller.probeState.probedPositions = [
+        { x: 1, y: 2, z: 3 },
+        { x: 4, y: 5, z: 6 },
+      ];
+      const file = tempFile('cncjs-tinyg-probe-save.txt');
+      const callback = jest.fn();
+
+      await new Promise((resolve) => {
+        controller.command('autolevel:saveToFile', file, (...args) => {
+          callback(...args);
+          resolve();
+        });
+      });
+
+      expect(callback).toHaveBeenCalledWith(null, { success: true, filepath: file });
+      expect(fs.readFileSync(file, 'utf8')).toBe('1 2 3 0 0 0 0 0 0\n4 5 6 0 0 0 0 0 0');
+    });
+
+    test('autolevel:applyProbeCompensation returns the compensated gcode via the callback', () => {
+      const { controller } = setupController();
+      const callback = jest.fn();
+      const probeData = [
+        { x: 0, y: 0, z: 0 },
+        { x: 10, y: 0, z: 0 },
+        { x: 0, y: 10, z: 0 },
+        { x: 10, y: 10, z: 0 },
+      ];
+
+      controller.command('autolevel:applyProbeCompensation', { gcode: 'M5\nG90', probeData }, callback);
+
+      expect(callback).toHaveBeenCalledWith(null, { compensatedGcode: 'M5\nG90' });
+    });
+  });
+
+  describe('negative cases', () => {
+    test('unknown command writes nothing', () => {
+      const { controller, writes } = setupController();
+
+      controller.command('nonexistent');
+
+      expect(writes).toEqual([]);
+    });
+
+    test('a closed connection suppresses client and feeder writes', () => {
+      const { controller, writes } = setupController();
+      controller.connection.isOpen = false;
+
+      controller.command('feedhold');
+      controller.command('gcode', 'G21\nG90');
+      controller.command('homing');
+
+      expect(writes).toEqual([]);
+    });
+  });
+});

--- a/src/server/controllers/__tests__/helpers/createController.js
+++ b/src/server/controllers/__tests__/helpers/createController.js
@@ -1,0 +1,14 @@
+export const createController = (ControllerClass, options = {}) => {
+  const writes = [];
+  const controller = new ControllerClass({ io: null }, {
+    port: '/dev/null',
+    baudrate: 115200,
+    rtscts: false,
+    ...options,
+  });
+  controller.connection = {
+    isOpen: true,
+    write: (data, context) => writes.push({ data, context }),
+  };
+  return { controller, writes };
+};


### PR DESCRIPTION
## Summary
- fix(marlin): homing sends G28 instead of TinyG-style G28.2 X Y Z
- test(controllers): new unit suites covering every command() handler of the Grbl, Marlin, Smoothie and TinyG controllers, asserting the exact bytes written to the serial connection
- Shared harness src/server/controllers/__tests__/helpers/createController.js used by all four suites
- docs/plans/controller-command-tests.md: test plan driving the change

## Verification
- yarn test: 510/510 green
- yarn eslint: 0 errors, 46 pre-existing warnings unchanged
- No controller source changes beyond the one-line homing fix