### PR TITLE
feat: add support for uploading files to the watch directory

### DIFF
--- a/.changeset/add-watch-directory-upload-option.md
+++ b/.changeset/add-watch-directory-upload-option.md
@@ -2,4 +2,4 @@
 "cncjs": minor
 ---
 
-Add an option to save uploaded G-code files to the configured watch directory, so they persist across sessions instead of only being loaded in memory.
+Rework the Watch Directory modal: add an "Add" button and a dropzone to upload files to the configured watch directory, with an upload progress indicator. The file tree updates in real time via server push events and also provides a Refresh button.

--- a/.changeset/add-watch-directory-upload-option.md
+++ b/.changeset/add-watch-directory-upload-option.md
@@ -1,5 +1,7 @@
 ---
-"cncjs": minor
+"cncjs": patch
 ---
+
+feat: add support for uploading files to the watch directory
 
 Rework the Watch Directory modal: add an "Add" button and a dropzone to upload files to the configured watch directory, with an upload progress indicator. The file tree updates in real time via server push events and also provides a Refresh button.

--- a/.changeset/add-watch-directory-upload-option.md
+++ b/.changeset/add-watch-directory-upload-option.md
@@ -1,0 +1,5 @@
+---
+"cncjs": minor
+---
+
+Add an option to save uploaded G-code files to the configured watch directory, so they persist across sessions instead of only being loaded in memory.

--- a/README.md
+++ b/README.md
@@ -289,7 +289,9 @@ Locale | Language | Status | Contributors
 [hu](https://github.com/cncjs/cncjs/tree/master/src/app/i18n/hu) | Magyar (Hungarian) | ✔ | Sipos Péter
 [it](https://github.com/cncjs/cncjs/tree/master/src/app/i18n/it) | Italiano (Italian) | ✔ | [vince87](https://github.com/vince87)
 [ja](https://github.com/cncjs/cncjs/tree/master/src/app/i18n/ja) | 日本語 (Japanese) | ✔ | [Naoki Okamoto](https://github.com/toonaoki)
+[nb](https://github.com/cncjs/cncjs/tree/master/src/app/i18n/nb) | Norsk (Norwegian) | ✔ | [Stian Kristensen](https://github.com/stianfk)
 [nl](https://github.com/cncjs/cncjs/tree/master/src/app/i18n/nl) | Nederlands (Netherlands) | ✔ | [dutchpatriot](https://github.com/dutchpatriot)
+[pt](https://github.com/cncjs/cncjs/tree/master/src/app/i18n/pt) | Português (Portugal) | ✔ | [Cheton Wu](https://github.com/cheton)
 [pt-br](https://github.com/cncjs/cncjs/tree/master/src/app/i18n/pt-br) | Português (Brasil) | ✔ | [cmsteinBR](https://github.com/cmsteinBR)
 [ru](https://github.com/cncjs/cncjs/tree/master/src/app/i18n/ru) | Ру́сский (Russian) | ✔ | [Denis Yusupov](https://github.com/minithc)
 [uk](https://github.com/cncjs/cncjs/tree/master/src/app/i18n/uk) | українська (Ukrainian) | ✔ | [khvalera](https://github.com/khvalera)

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "start-server-dev": "cross-env NODE_ENV=development ./bin/cncjs --port 8000 -m /widget:https://cncjs.github.io/cncjs-widget-boilerplate/v1/",
     "lint": "concurrently --kill-others-on-fail --names \"i18nlint,eslint,stylint\" \"yarn i18nlint\" \"yarn eslint\" \"yarn stylint\"",
     "eslint": "eslint --color src/**/*.js src/app/**/*.jsx scripts/**/*.js",
-    "eslint-debug": "DEBUG=\"eslint:glob-util,eslint:config-*,eslint:cli*\" eslint --cache --color --quiet src/**/*.js src/app/**/*.jsx scripts/**/*.js",
+    "eslint-debug": "cross-env DEBUG=\"eslint:glob-util,eslint:config-*,eslint:cli*\" eslint --cache --color --quiet src/**/*.js src/app/**/*.jsx scripts/**/*.js",
     "i18nlint": "bash -c 'find src/{app,server}/i18n -type f -name \"*.json\" | xargs -L1 -I{} -- bash -c \"echo Linting {}; jsonlint -q {}\"'",
     "stylint": "stylint src/app",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -228,7 +228,7 @@
     "react-final-form": "~3.7.0",
     "react-foreach": "~0.1.1",
     "react-ga4": "^2.1.0",
-    "react-i18next": "~11.18.6",
+    "react-i18next": "^8.0.0",
     "react-icon-base": "~2.1.2",
     "react-infinite-tree": "~0.7.1",
     "react-redux": "~5.0.7",

--- a/src/app/api/index.js
+++ b/src/app/api/index.js
@@ -260,18 +260,23 @@ watch.readFile = (options) => new Promise((resolve, reject) => {
 });
 
 watch.uploadFile = (options) => new Promise((resolve, reject) => {
-  const { file, data } = { ...options };
+  const { file, data, onProgress } = { ...options };
 
-  authrequest
+  const request = authrequest
     .put('/api/watch/file')
-    .send({ file, data })
-    .end((err, res) => {
-      if (err) {
-        reject(res);
-      } else {
-        resolve(res);
-      }
-    });
+    .send({ file, data });
+
+  if (typeof onProgress === 'function') {
+    request.on('progress', onProgress);
+  }
+
+  request.end((err, res) => {
+    if (err) {
+      reject(res);
+    } else {
+      resolve(res);
+    }
+  });
 });
 
 //

--- a/src/app/api/index.js
+++ b/src/app/api/index.js
@@ -217,6 +217,18 @@ controllers.get = () => new Promise((resolve, reject) => {
 //
 const watch = {};
 
+watch.getStatus = () => new Promise((resolve, reject) => {
+  authrequest
+    .get('/api/watch/status')
+    .end((err, res) => {
+      if (err) {
+        reject(res);
+      } else {
+        resolve(res);
+      }
+    });
+});
+
 watch.getFiles = (options) => new Promise((resolve, reject) => {
   const { path } = { ...options };
 
@@ -238,6 +250,21 @@ watch.readFile = (options) => new Promise((resolve, reject) => {
   authrequest
     .post('/api/watch/file')
     .send({ file })
+    .end((err, res) => {
+      if (err) {
+        reject(res);
+      } else {
+        resolve(res);
+      }
+    });
+});
+
+watch.uploadFile = (options) => new Promise((resolve, reject) => {
+  const { file, data } = { ...options };
+
+  authrequest
+    .put('/api/watch/file')
+    .send({ file, data })
     .end((err, res) => {
       if (err) {
         reject(res);

--- a/src/app/i18n/cs/resource.json
+++ b/src/app/i18n/cs/resource.json
@@ -646,6 +646,5 @@
   "Start Z: {{value}} {{- units}}": "Počáteční Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Koncové Z: {{value}} {{- units}}",
   "None": "Žádný",
-  "No watch directory is configured on the server": "",
   "Save to Watch Directory": ""
 }

--- a/src/app/i18n/cs/resource.json
+++ b/src/app/i18n/cs/resource.json
@@ -645,5 +645,7 @@
   "Clearance Z: {{value}} {{- units}}": "Výška přejezdu Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Počáteční Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Koncové Z: {{value}} {{- units}}",
-  "None": "Žádný"
+  "None": "Žádný",
+  "No watch directory is configured on the server": "",
+  "Save to Watch Directory": ""
 }

--- a/src/app/i18n/cs/resource.json
+++ b/src/app/i18n/cs/resource.json
@@ -519,8 +519,6 @@
   "New Account": "Nový účet",
   "Hide Limits": "Skrýt omezení",
   "Show Limits": "Zobrazit omezení",
-  "WebGL: <1>Enabled</1>": "WebGL: <1>Povoleno</1>",
-  "WebGL: <1>Disabled</1>": "WebGL: <1>Zakázáno</1>",
   "Hide Cutting Tool": "Skrýt řezný nástroj",
   "Show Cutting Tool": "Zobrazit řezný nástroj",
   "Ready to start": "Připraven k zahájení",
@@ -646,5 +644,7 @@
   "Start Z: {{value}} {{- units}}": "Počáteční Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Koncové Z: {{value}} {{- units}}",
   "None": "Žádný",
-  "Save to Watch Directory": ""
+  "WebGL:": "WebGL:",
+  "Drop files to upload": "Přetáhněte sem soubory k nahrání",
+  "Uploading...": "Nahrávání..."
 }

--- a/src/app/i18n/de/resource.json
+++ b/src/app/i18n/de/resource.json
@@ -644,6 +644,5 @@
   "Start Z: {{value}} {{- units}}": "Start-Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "End-Z: {{value}} {{- units}}",
   "None": "Keine",
-  "No watch directory is configured on the server": "",
   "Save to Watch Directory": ""
 }

--- a/src/app/i18n/de/resource.json
+++ b/src/app/i18n/de/resource.json
@@ -519,8 +519,6 @@
   "New Account": "Neues Konto",
   "Hide Limits": "Grenzwerte ausblenden",
   "Show Limits": "Grenzwerte anzeigen",
-  "WebGL: <1>Enabled</1>": "WebGL: <1>Aktiviert</1>",
-  "WebGL: <1>Disabled</1>": "WebGL: <1>Deaktiviert</1>",
   "Hide Cutting Tool": "Schneidwerkzeug ausblenden",
   "Show Cutting Tool": "Schneidwerkzeug anzeigen",
   "Ready to start": "Bereit zum Starten",
@@ -644,5 +642,7 @@
   "Start Z: {{value}} {{- units}}": "Start-Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "End-Z: {{value}} {{- units}}",
   "None": "Keine",
-  "Save to Watch Directory": ""
+  "WebGL:": "WebGL:",
+  "Drop files to upload": "Dateien zum Hochladen hier ablegen",
+  "Uploading...": "Wird hochgeladen..."
 }

--- a/src/app/i18n/de/resource.json
+++ b/src/app/i18n/de/resource.json
@@ -643,5 +643,7 @@
   "Clearance Z: {{value}} {{- units}}": "Freifahrhöhe Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Start-Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "End-Z: {{value}} {{- units}}",
-  "None": "Keine"
+  "None": "Keine",
+  "No watch directory is configured on the server": "",
+  "Save to Watch Directory": ""
 }

--- a/src/app/i18n/en/resource.json
+++ b/src/app/i18n/en/resource.json
@@ -467,7 +467,6 @@
   "Move the camera": "Move the camera",
   "Rotate the camera": "Rotate the camera",
   "Watch Directory": "Watch Directory",
-  "Save to Watch Directory": "Save to Watch Directory",
   "Date modified": "Date modified",
   "Type": "Type",
   "Size": "Size",
@@ -520,8 +519,6 @@
   "New Account": "New Account",
   "Hide Limits": "Hide Limits",
   "Show Limits": "Show Limits",
-  "WebGL: <1>Enabled</1>": "WebGL: <1>Enabled</1>",
-  "WebGL: <1>Disabled</1>": "WebGL: <1>Disabled</1>",
   "Hide Cutting Tool": "Hide Cutting Tool",
   "Show Cutting Tool": "Show Cutting Tool",
   "Ready to start": "Ready to start",
@@ -644,5 +641,8 @@
   "Clearance Z: {{value}} {{- units}}": "Clearance Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Start Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "End Z: {{value}} {{- units}}",
-  "None": "None"
+  "None": "None",
+  "WebGL:": "WebGL:",
+  "Drop files to upload": "Drop files to upload",
+  "Uploading...": "Uploading..."
 }

--- a/src/app/i18n/en/resource.json
+++ b/src/app/i18n/en/resource.json
@@ -468,7 +468,6 @@
   "Rotate the camera": "Rotate the camera",
   "Watch Directory": "Watch Directory",
   "Save to Watch Directory": "Save to Watch Directory",
-  "No watch directory is configured on the server": "No watch directory is configured on the server",
   "Date modified": "Date modified",
   "Type": "Type",
   "Size": "Size",

--- a/src/app/i18n/en/resource.json
+++ b/src/app/i18n/en/resource.json
@@ -467,6 +467,8 @@
   "Move the camera": "Move the camera",
   "Rotate the camera": "Rotate the camera",
   "Watch Directory": "Watch Directory",
+  "Save to Watch Directory": "Save to Watch Directory",
+  "No watch directory is configured on the server": "No watch directory is configured on the server",
   "Date modified": "Date modified",
   "Type": "Type",
   "Size": "Size",

--- a/src/app/i18n/es/resource.json
+++ b/src/app/i18n/es/resource.json
@@ -645,6 +645,5 @@
   "Start Z: {{value}} {{- units}}": "Z inicial: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Z final: {{value}} {{- units}}",
   "None": "Ninguno",
-  "No watch directory is configured on the server": "",
   "Save to Watch Directory": ""
 }

--- a/src/app/i18n/es/resource.json
+++ b/src/app/i18n/es/resource.json
@@ -644,5 +644,7 @@
   "Clearance Z: {{value}} {{- units}}": "Z de separación: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Z inicial: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Z final: {{value}} {{- units}}",
-  "None": "Ninguno"
+  "None": "Ninguno",
+  "No watch directory is configured on the server": "",
+  "Save to Watch Directory": ""
 }

--- a/src/app/i18n/es/resource.json
+++ b/src/app/i18n/es/resource.json
@@ -519,8 +519,6 @@
   "New Account": "Nueva cuenta",
   "Hide Limits": "Ocultar límites",
   "Show Limits": "Mostrar límites",
-  "WebGL: <1>Enabled</1>": "WebGL: <1>Activado</1>",
-  "WebGL: <1>Disabled</1>": "WebGL: <1>Desactivado</1>",
   "Hide Cutting Tool": "Ocultar herramienta de corte",
   "Show Cutting Tool": "Mostrar herramienta de corte",
   "Ready to start": "Listo para iniciar",
@@ -645,5 +643,7 @@
   "Start Z: {{value}} {{- units}}": "Z inicial: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Z final: {{value}} {{- units}}",
   "None": "Ninguno",
-  "Save to Watch Directory": ""
+  "WebGL:": "WebGL:",
+  "Drop files to upload": "Suelte los archivos para subirlos",
+  "Uploading...": "Subiendo..."
 }

--- a/src/app/i18n/fr/resource.json
+++ b/src/app/i18n/fr/resource.json
@@ -644,5 +644,7 @@
   "Clearance Z: {{value}} {{- units}}": "Z de dégagement : {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Z de départ : {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Z de fin : {{value}} {{- units}}",
-  "None": "Aucun"
+  "None": "Aucun",
+  "No watch directory is configured on the server": "",
+  "Save to Watch Directory": ""
 }

--- a/src/app/i18n/fr/resource.json
+++ b/src/app/i18n/fr/resource.json
@@ -645,6 +645,5 @@
   "Start Z: {{value}} {{- units}}": "Z de départ : {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Z de fin : {{value}} {{- units}}",
   "None": "Aucun",
-  "No watch directory is configured on the server": "",
   "Save to Watch Directory": ""
 }

--- a/src/app/i18n/fr/resource.json
+++ b/src/app/i18n/fr/resource.json
@@ -519,8 +519,6 @@
   "New Account": "Nouveau compte",
   "Hide Limits": "Masquer les limites",
   "Show Limits": "Afficher les limites",
-  "WebGL: <1>Enabled</1>": "WebGL : <1>Activé</1>",
-  "WebGL: <1>Disabled</1>": "WebGL : <1>Désactivé</1>",
   "Hide Cutting Tool": "Masquer l'outil de coupe",
   "Show Cutting Tool": "Afficher l'outil de coupe",
   "Ready to start": "Prêt à démarrer",
@@ -645,5 +643,7 @@
   "Start Z: {{value}} {{- units}}": "Z de départ : {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Z de fin : {{value}} {{- units}}",
   "None": "Aucun",
-  "Save to Watch Directory": ""
+  "WebGL:": "WebGL :",
+  "Drop files to upload": "Déposez les fichiers à charger",
+  "Uploading...": "Chargement..."
 }

--- a/src/app/i18n/hu/resource.json
+++ b/src/app/i18n/hu/resource.json
@@ -643,5 +643,7 @@
   "Clearance Z: {{value}} {{- units}}": "Z biztonsági magasság: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Kezdeti Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Végső Z: {{value}} {{- units}}",
-  "None": "Nincs"
+  "None": "Nincs",
+  "No watch directory is configured on the server": "",
+  "Save to Watch Directory": ""
 }

--- a/src/app/i18n/hu/resource.json
+++ b/src/app/i18n/hu/resource.json
@@ -519,8 +519,6 @@
   "New Account": "Új fiók",
   "Hide Limits": "Határok elrejtése",
   "Show Limits": "Határok megjelenítése",
-  "WebGL: <1>Enabled</1>": "WebGL: <1>Engedélyezve</1>",
-  "WebGL: <1>Disabled</1>": "WebGL: <1>Tiltva</1>",
   "Hide Cutting Tool": "Vágószerszám elrejtése",
   "Show Cutting Tool": "Vágószerszám megjelenítése",
   "Ready to start": "Készen áll az indításra",
@@ -644,5 +642,7 @@
   "Start Z: {{value}} {{- units}}": "Kezdeti Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Végső Z: {{value}} {{- units}}",
   "None": "Nincs",
-  "Save to Watch Directory": ""
+  "WebGL:": "WebGL:",
+  "Drop files to upload": "Húzd ide a feltöltendő fájlokat",
+  "Uploading...": "Feltöltés..."
 }

--- a/src/app/i18n/hu/resource.json
+++ b/src/app/i18n/hu/resource.json
@@ -644,6 +644,5 @@
   "Start Z: {{value}} {{- units}}": "Kezdeti Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Végső Z: {{value}} {{- units}}",
   "None": "Nincs",
-  "No watch directory is configured on the server": "",
   "Save to Watch Directory": ""
 }

--- a/src/app/i18n/it/resource.json
+++ b/src/app/i18n/it/resource.json
@@ -644,5 +644,7 @@
   "Clearance Z: {{value}} {{- units}}": "Z di sicurezza: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Z iniziale: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Z finale: {{value}} {{- units}}",
-  "None": "Nessuno"
+  "None": "Nessuno",
+  "No watch directory is configured on the server": "",
+  "Save to Watch Directory": ""
 }

--- a/src/app/i18n/it/resource.json
+++ b/src/app/i18n/it/resource.json
@@ -519,8 +519,6 @@
   "New Account": "Nuovo account",
   "Hide Limits": "Nascondi Limiti",
   "Show Limits": "Mostra Limiti",
-  "WebGL: <1>Enabled</1>": "WebGL: <1>Attivato</1>",
-  "WebGL: <1>Disabled</1>": "WebGL: <1>Disattivato</1>",
   "Hide Cutting Tool": "Nascondi Utensile da Taglio",
   "Show Cutting Tool": "Mostra Utensile da Taglio",
   "Ready to start": "Pronto per iniziare",
@@ -645,5 +643,7 @@
   "Start Z: {{value}} {{- units}}": "Z iniziale: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Z finale: {{value}} {{- units}}",
   "None": "Nessuno",
-  "Save to Watch Directory": ""
+  "WebGL:": "WebGL:",
+  "Drop files to upload": "Trascina qui i file da caricare",
+  "Uploading...": "Caricamento..."
 }

--- a/src/app/i18n/it/resource.json
+++ b/src/app/i18n/it/resource.json
@@ -645,6 +645,5 @@
   "Start Z: {{value}} {{- units}}": "Z iniziale: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Z finale: {{value}} {{- units}}",
   "None": "Nessuno",
-  "No watch directory is configured on the server": "",
   "Save to Watch Directory": ""
 }

--- a/src/app/i18n/ja/resource.json
+++ b/src/app/i18n/ja/resource.json
@@ -643,6 +643,5 @@
   "Start Z: {{value}} {{- units}}": "開始Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "終了Z: {{value}} {{- units}}",
   "None": "なし",
-  "No watch directory is configured on the server": "",
   "Save to Watch Directory": ""
 }

--- a/src/app/i18n/ja/resource.json
+++ b/src/app/i18n/ja/resource.json
@@ -642,5 +642,7 @@
   "Clearance Z: {{value}} {{- units}}": "クリアランスZ: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "開始Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "終了Z: {{value}} {{- units}}",
-  "None": "なし"
+  "None": "なし",
+  "No watch directory is configured on the server": "",
+  "Save to Watch Directory": ""
 }

--- a/src/app/i18n/ja/resource.json
+++ b/src/app/i18n/ja/resource.json
@@ -519,8 +519,6 @@
   "New Account": "新規アカウント",
   "Hide Limits": "限界を隠す",
   "Show Limits": "限界を表示する",
-  "WebGL: <1>Enabled</1>": "WebGL: <1>有効</1>",
-  "WebGL: <1>Disabled</1>": "WebGL: <1>無効</1>",
   "Hide Cutting Tool": "工具を隠す",
   "Show Cutting Tool": "工具を表示する",
   "Ready to start": "スタートの準備ができました",
@@ -643,5 +641,7 @@
   "Start Z: {{value}} {{- units}}": "開始Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "終了Z: {{value}} {{- units}}",
   "None": "なし",
-  "Save to Watch Directory": ""
+  "WebGL:": "WebGL:",
+  "Drop files to upload": "アップロードするファイルをここにドラッグ＆ドロップ",
+  "Uploading...": "アップロード中..."
 }

--- a/src/app/i18n/nb/resource.json
+++ b/src/app/i18n/nb/resource.json
@@ -644,6 +644,5 @@
   "Start Z: {{value}} {{- units}}": "Start-Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Slutt-Z: {{value}} {{- units}}",
   "None": "Ingen",
-  "No watch directory is configured on the server": "",
   "Save to Watch Directory": ""
 }

--- a/src/app/i18n/nb/resource.json
+++ b/src/app/i18n/nb/resource.json
@@ -519,8 +519,6 @@
   "New Account": "Ny Konto",
   "Hide Limits": "Skjul grenser",
   "Show Limits": "Vis grenser",
-  "WebGL: <1>Enabled</1>": "WebGL: <1>skrudd på</1>",
-  "WebGL: <1>Disabled</1>": "WebGL: <1>skrudd av</1>",
   "Hide Cutting Tool": "Skjul skjæreverktøy",
   "Show Cutting Tool": "Vis skjæreverktøy",
   "Ready to start": "Klar til å starte",
@@ -644,5 +642,7 @@
   "Start Z: {{value}} {{- units}}": "Start-Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Slutt-Z: {{value}} {{- units}}",
   "None": "Ingen",
-  "Save to Watch Directory": ""
+  "WebGL:": "WebGL:",
+  "Drop files to upload": "Slipp filer her for å laste opp",
+  "Uploading...": "Laster opp..."
 }

--- a/src/app/i18n/nb/resource.json
+++ b/src/app/i18n/nb/resource.json
@@ -643,5 +643,7 @@
   "Clearance Z: {{value}} {{- units}}": "Frihøyde Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Start-Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Slutt-Z: {{value}} {{- units}}",
-  "None": "Ingen"
+  "None": "Ingen",
+  "No watch directory is configured on the server": "",
+  "Save to Watch Directory": ""
 }

--- a/src/app/i18n/nl/resource.json
+++ b/src/app/i18n/nl/resource.json
@@ -643,5 +643,7 @@
   "Clearance Z: {{value}} {{- units}}": "Vrijloophoogte Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Start-Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Eind-Z: {{value}} {{- units}}",
-  "None": "Geen"
+  "None": "Geen",
+  "No watch directory is configured on the server": "",
+  "Save to Watch Directory": ""
 }

--- a/src/app/i18n/nl/resource.json
+++ b/src/app/i18n/nl/resource.json
@@ -644,6 +644,5 @@
   "Start Z: {{value}} {{- units}}": "Start-Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Eind-Z: {{value}} {{- units}}",
   "None": "Geen",
-  "No watch directory is configured on the server": "",
   "Save to Watch Directory": ""
 }

--- a/src/app/i18n/nl/resource.json
+++ b/src/app/i18n/nl/resource.json
@@ -519,8 +519,6 @@
   "New Account": "Nieuw Account",
   "Hide Limits": "Verberg Limieten",
   "Show Limits": "Laat Limieten Zien",
-  "WebGL: <1>Enabled</1>": "WebGL: <1>Aanzetten</1>",
-  "WebGL: <1>Disabled</1>": "WebGL: <1>Uitzetten</1>",
   "Hide Cutting Tool": "Verberg Gereedschap",
   "Show Cutting Tool": "Laat Gereedschap Zien",
   "Ready to start": "Klaar om te starten",
@@ -644,5 +642,7 @@
   "Start Z: {{value}} {{- units}}": "Start-Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Eind-Z: {{value}} {{- units}}",
   "None": "Geen",
-  "Save to Watch Directory": ""
+  "WebGL:": "WebGL:",
+  "Drop files to upload": "Sleep bestanden hierheen om ze te uploaden",
+  "Uploading...": "Bezig met uploaden..."
 }

--- a/src/app/i18n/pt-br/resource.json
+++ b/src/app/i18n/pt-br/resource.json
@@ -645,6 +645,5 @@
   "Start Z: {{value}} {{- units}}": "Z inicial: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Z final: {{value}} {{- units}}",
   "None": "Nenhum",
-  "No watch directory is configured on the server": "",
   "Save to Watch Directory": ""
 }

--- a/src/app/i18n/pt-br/resource.json
+++ b/src/app/i18n/pt-br/resource.json
@@ -519,8 +519,6 @@
   "New Account": "Nova Conta",
   "Hide Limits": "Ocultar Limites",
   "Show Limits": "Mostrar Limites",
-  "WebGL: <1>Enabled</1>": "WebGL: <1>Ativado</1>",
-  "WebGL: <1>Disabled</1>": "WebGL: <1>Desativado</1>",
   "Hide Cutting Tool": "Ocultar Ferramenta de Corte",
   "Show Cutting Tool": "Mostrar Ferramenta de Corte",
   "Ready to start": "Pronto para começar",
@@ -645,5 +643,7 @@
   "Start Z: {{value}} {{- units}}": "Z inicial: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Z final: {{value}} {{- units}}",
   "None": "Nenhum",
-  "Save to Watch Directory": ""
+  "WebGL:": "WebGL:",
+  "Drop files to upload": "Solte os arquivos para enviar",
+  "Uploading...": "Enviando..."
 }

--- a/src/app/i18n/pt-br/resource.json
+++ b/src/app/i18n/pt-br/resource.json
@@ -644,5 +644,7 @@
   "Clearance Z: {{value}} {{- units}}": "Z de folga: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Z inicial: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Z final: {{value}} {{- units}}",
-  "None": "Nenhum"
+  "None": "Nenhum",
+  "No watch directory is configured on the server": "",
+  "Save to Watch Directory": ""
 }

--- a/src/app/i18n/pt/resource.json
+++ b/src/app/i18n/pt/resource.json
@@ -645,6 +645,5 @@
   "Start Z: {{value}} {{- units}}": "Z inicial: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Z final: {{value}} {{- units}}",
   "None": "Nenhum",
-  "No watch directory is configured on the server": "",
   "Save to Watch Directory": ""
 }

--- a/src/app/i18n/pt/resource.json
+++ b/src/app/i18n/pt/resource.json
@@ -519,8 +519,6 @@
   "New Account": "Nova Conta",
   "Hide Limits": "Ocultar Limites",
   "Show Limits": "Mostrar Limites",
-  "WebGL: <1>Enabled</1>": "WebGL: <1>Ativado</1>",
-  "WebGL: <1>Disabled</1>": "WebGL: <1>Desativado</1>",
   "Hide Cutting Tool": "Ocultar Ferramenta de Corte",
   "Show Cutting Tool": "Mostrar Ferramenta de Corte",
   "Ready to start": "Pronto para começar",
@@ -645,5 +643,7 @@
   "Start Z: {{value}} {{- units}}": "Z inicial: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Z final: {{value}} {{- units}}",
   "None": "Nenhum",
-  "Save to Watch Directory": ""
+  "WebGL:": "WebGL:",
+  "Drop files to upload": "Solte os arquivos para enviar",
+  "Uploading...": "Enviando..."
 }

--- a/src/app/i18n/pt/resource.json
+++ b/src/app/i18n/pt/resource.json
@@ -644,5 +644,7 @@
   "Clearance Z: {{value}} {{- units}}": "Z de folga: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Z inicial: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Z final: {{value}} {{- units}}",
-  "None": "Nenhum"
+  "None": "Nenhum",
+  "No watch directory is configured on the server": "",
+  "Save to Watch Directory": ""
 }

--- a/src/app/i18n/ru/resource.json
+++ b/src/app/i18n/ru/resource.json
@@ -645,5 +645,7 @@
   "Clearance Z: {{value}} {{- units}}": "Высота подъёма Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Начальная Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Конечная Z: {{value}} {{- units}}",
-  "None": "Нет"
+  "None": "Нет",
+  "No watch directory is configured on the server": "",
+  "Save to Watch Directory": ""
 }

--- a/src/app/i18n/ru/resource.json
+++ b/src/app/i18n/ru/resource.json
@@ -519,8 +519,6 @@
   "New Account": "Создать учетную запись",
   "Hide Limits": "Скрыть ограничения",
   "Show Limits": "Показать ограничения",
-  "WebGL: <1>Enabled</1>": "WebGL: <1>Включено</1>",
-  "WebGL: <1>Disabled</1>": "WebGL: <1>Отключено</1>",
   "Hide Cutting Tool": "Скрыть режущий инструмент",
   "Show Cutting Tool": "Показать режущий инструмент",
   "Ready to start": "Готов к запуску",
@@ -646,5 +644,7 @@
   "Start Z: {{value}} {{- units}}": "Начальная Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Конечная Z: {{value}} {{- units}}",
   "None": "Нет",
-  "Save to Watch Directory": ""
+  "WebGL:": "WebGL:",
+  "Drop files to upload": "Перетащите файлы для загрузки",
+  "Uploading...": "Загрузка..."
 }

--- a/src/app/i18n/ru/resource.json
+++ b/src/app/i18n/ru/resource.json
@@ -646,6 +646,5 @@
   "Start Z: {{value}} {{- units}}": "Начальная Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Конечная Z: {{value}} {{- units}}",
   "None": "Нет",
-  "No watch directory is configured on the server": "",
   "Save to Watch Directory": ""
 }

--- a/src/app/i18n/tr/resource.json
+++ b/src/app/i18n/tr/resource.json
@@ -644,6 +644,5 @@
   "Start Z: {{value}} {{- units}}": "Başlangıç Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Bitiş Z: {{value}} {{- units}}",
   "None": "Yok",
-  "No watch directory is configured on the server": "",
   "Save to Watch Directory": ""
 }

--- a/src/app/i18n/tr/resource.json
+++ b/src/app/i18n/tr/resource.json
@@ -643,5 +643,7 @@
   "Clearance Z: {{value}} {{- units}}": "Güvenlik Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Başlangıç Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Bitiş Z: {{value}} {{- units}}",
-  "None": "Yok"
+  "None": "Yok",
+  "No watch directory is configured on the server": "",
+  "Save to Watch Directory": ""
 }

--- a/src/app/i18n/tr/resource.json
+++ b/src/app/i18n/tr/resource.json
@@ -519,8 +519,6 @@
   "New Account": "Yeni Hesap",
   "Hide Limits": "Sınırları Gizle",
   "Show Limits": "Sınırları Göster",
-  "WebGL: <1>Enabled</1>": "WebGL: <1>Etkin</1>",
-  "WebGL: <1>Disabled</1>": "WebGL: <1>Engelle</1>",
   "Hide Cutting Tool": "Kesici Aleti Gizle",
   "Show Cutting Tool": "Kesici Aleti Göster",
   "Ready to start": "Başlamaya Hazır",
@@ -644,5 +642,7 @@
   "Start Z: {{value}} {{- units}}": "Başlangıç Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Bitiş Z: {{value}} {{- units}}",
   "None": "Yok",
-  "Save to Watch Directory": ""
+  "WebGL:": "WebGL:",
+  "Drop files to upload": "Yüklenecek dosyaları buraya sürükleyin",
+  "Uploading...": "Yükleniyor..."
 }

--- a/src/app/i18n/uk/resource.json
+++ b/src/app/i18n/uk/resource.json
@@ -645,5 +645,7 @@
   "Clearance Z: {{value}} {{- units}}": "Висота підйому Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "Початкова Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Кінцева Z: {{value}} {{- units}}",
-  "None": "Немає"
+  "None": "Немає",
+  "No watch directory is configured on the server": "",
+  "Save to Watch Directory": ""
 }

--- a/src/app/i18n/uk/resource.json
+++ b/src/app/i18n/uk/resource.json
@@ -474,8 +474,6 @@
   "Click the Stop button to stop program execution.": "Натисніть кнопку Зупинити, щоб зупинити виконання програми.",
   "Run a tool change macro to change the tool and adjust the Z-axis offset. Afterwards, click the Resume button to resume program execution.": "Щоб змінити інструмент і налаштувати зміщення по осі Z, запустіть макрос зміни інструменту. Після цього натисніть кнопку «Відновити», щоб відновити виконання програми.",
   "Waiting for the target temperature to be reached...": "Очікування досягнення цільової температури...",
-  "WebGL: <1>Enabled</1>": "WebGL: <1>Enabled</1>",
-  "WebGL: <1>Disabled</1>": "WebGL: <1>Disabled</1>",
   "Work Coordinate System": "Робоча система координат",
   "Enable 3D View": "Увімкніть 3D-перегляд",
   "Disable 3D View": "Вимкнути 3D-перегляд",
@@ -646,5 +644,7 @@
   "Start Z: {{value}} {{- units}}": "Початкова Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Кінцева Z: {{value}} {{- units}}",
   "None": "Немає",
-  "Save to Watch Directory": ""
+  "WebGL:": "WebGL:",
+  "Drop files to upload": "Перетягніть файли для завантаження",
+  "Uploading...": "Завантаження..."
 }

--- a/src/app/i18n/uk/resource.json
+++ b/src/app/i18n/uk/resource.json
@@ -646,6 +646,5 @@
   "Start Z: {{value}} {{- units}}": "Початкова Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "Кінцева Z: {{value}} {{- units}}",
   "None": "Немає",
-  "No watch directory is configured on the server": "",
   "Save to Watch Directory": ""
 }

--- a/src/app/i18n/zh-cn/resource.json
+++ b/src/app/i18n/zh-cn/resource.json
@@ -642,5 +642,7 @@
   "Clearance Z: {{value}} {{- units}}": "安全高度Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "起始Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "终止Z: {{value}} {{- units}}",
-  "None": "无"
+  "None": "无",
+  "No watch directory is configured on the server": "",
+  "Save to Watch Directory": ""
 }

--- a/src/app/i18n/zh-cn/resource.json
+++ b/src/app/i18n/zh-cn/resource.json
@@ -519,8 +519,6 @@
   "New Account": "新账号",
   "Hide Limits": "隐藏限制",
   "Show Limits": "显示限制",
-  "WebGL: <1>Enabled</1>": "WebGL: <1>已启用</1>",
-  "WebGL: <1>Disabled</1>": "WebGL: <1>已关闭</1>",
   "Hide Cutting Tool": "隐藏切削刀具",
   "Show Cutting Tool": "显示切削刀具",
   "Ready to start": "准备开始",
@@ -643,5 +641,7 @@
   "Start Z: {{value}} {{- units}}": "起始Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "终止Z: {{value}} {{- units}}",
   "None": "无",
-  "Save to Watch Directory": ""
+  "WebGL:": "WebGL:",
+  "Drop files to upload": "将文件拖拽至此处上传",
+  "Uploading...": "正在上传..."
 }

--- a/src/app/i18n/zh-cn/resource.json
+++ b/src/app/i18n/zh-cn/resource.json
@@ -643,6 +643,5 @@
   "Start Z: {{value}} {{- units}}": "起始Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "终止Z: {{value}} {{- units}}",
   "None": "无",
-  "No watch directory is configured on the server": "",
   "Save to Watch Directory": ""
 }

--- a/src/app/i18n/zh-tw/resource.json
+++ b/src/app/i18n/zh-tw/resource.json
@@ -642,5 +642,7 @@
   "Clearance Z: {{value}} {{- units}}": "安全高度Z: {{value}} {{- units}}",
   "Start Z: {{value}} {{- units}}": "起始Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "終止Z: {{value}} {{- units}}",
-  "None": "無"
+  "None": "無",
+  "No watch directory is configured on the server": "",
+  "Save to Watch Directory": ""
 }

--- a/src/app/i18n/zh-tw/resource.json
+++ b/src/app/i18n/zh-tw/resource.json
@@ -643,6 +643,5 @@
   "Start Z: {{value}} {{- units}}": "起始Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "終止Z: {{value}} {{- units}}",
   "None": "無",
-  "No watch directory is configured on the server": "",
   "Save to Watch Directory": ""
 }

--- a/src/app/i18n/zh-tw/resource.json
+++ b/src/app/i18n/zh-tw/resource.json
@@ -519,8 +519,6 @@
   "New Account": "新增帳號",
   "Hide Limits": "隱藏限制",
   "Show Limits": "顯示限制",
-  "WebGL: <1>Enabled</1>": "WebGL: <1>已啟用</1>",
-  "WebGL: <1>Disabled</1>": "WebGL: <1>已停用</1>",
   "Hide Cutting Tool": "隱藏切割刀具",
   "Show Cutting Tool": "顯示切割刀具",
   "Ready to start": "準備開始",
@@ -643,5 +641,7 @@
   "Start Z: {{value}} {{- units}}": "起始Z: {{value}} {{- units}}",
   "End Z: {{value}} {{- units}}": "終止Z: {{value}} {{- units}}",
   "None": "無",
-  "Save to Watch Directory": ""
+  "WebGL:": "WebGL:",
+  "Drop files to upload": "將檔案拖曳至此處上傳",
+  "Uploading...": "正在上傳..."
 }

--- a/src/app/lib/controller/Controller.js
+++ b/src/app/lib/controller/Controller.js
@@ -50,6 +50,7 @@ class Controller {
         'controller:settings': [],
         'controller:state': [],
         'message': [],
+        'watchdir:change': [],
 
         /**
          * [Autolevel] Fired when the auto-leveling process starts.

--- a/src/app/widgets/Visualizer/PrimaryToolbar.jsx
+++ b/src/app/widgets/Visualizer/PrimaryToolbar.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { Button } from 'app/components/Buttons';
 import Dropdown, { MenuItem } from 'app/components/Dropdown';
-import I18n from 'app/components/I18n';
 import Space from 'app/components/Space';
 import controller from 'app/lib/controller';
 import i18n from 'app/lib/i18n';
@@ -328,20 +327,20 @@ class PrimaryToolbar extends PureComponent {
                   header
                 >
                   {WebGL.isWebGLAvailable() && (
-                    <I18n>
-                      {'WebGL: '}
-                      <span style={{ color: colornames('royalblue') }}>
-                        Enabled
+                    <div>
+                      {i18n._('WebGL:')}
+                      <span style={{ marginLeft: 4, color: colornames('royalblue') }}>
+                        {i18n._('Enabled')}
                       </span>
-                    </I18n>
+                    </div>
                   )}
                   {!WebGL.isWebGLAvailable() && (
-                    <I18n>
-                      {'WebGL: '}
-                      <span style={{ color: colornames('crimson') }}>
-                        Disabled
+                    <div>
+                      {i18n._('WebGL:')}
+                      <span style={{ marginLeft: 4, color: colornames('crimson') }}>
+                        {i18n._('Disabled')}
                       </span>
-                    </I18n>
+                    </div>
                   )}
                 </MenuItem>
                 <MenuItem divider />

--- a/src/app/widgets/Visualizer/WatchDirectory.jsx
+++ b/src/app/widgets/Visualizer/WatchDirectory.jsx
@@ -1,13 +1,18 @@
 import path from 'path';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import ReactDOM from 'react-dom';
 import InfiniteTree from 'react-infinite-tree';
 import api from 'app/api';
 import Modal from 'app/components/Modal';
+import Space from 'app/components/Space';
+import controller from 'app/lib/controller';
 import i18n from 'app/lib/i18n';
+import log from 'app/lib/log';
 import renderer from './renderer';
 import styles from './renderer.styl';
+import watchDirectoryStyles from './watch-directory.styl';
 
 class WatchDirectory extends PureComponent {
     static propTypes = {
@@ -19,8 +24,65 @@ class WatchDirectory extends PureComponent {
 
     treeNode = null;
 
+    uploadInputEl = null;
+
+    dropzoneNode = null;
+
+    state = {
+      dragging: false,
+      uploading: false,
+      uploadProgress: 0,
+      refreshing: false
+    };
+
     componentDidMount() {
       this.addResizeEventListener();
+      this.addDropZoneEventListeners();
+      this.loadFiles();
+      controller.addListener('watchdir:change', this.handleWatchDirChange);
+    }
+
+    componentWillUnmount() {
+      this.removeResizeEventListener();
+      this.removeDropZoneEventListeners();
+      controller.removeListener('watchdir:change', this.handleWatchDirChange);
+    }
+
+    addDropZoneEventListeners() {
+      this.dropzoneNode.addEventListener('dragover', this.handleDragOver);
+      this.dropzoneNode.addEventListener('dragleave', this.handleDragLeave);
+      this.dropzoneNode.addEventListener('drop', this.handleDrop);
+    }
+
+    removeDropZoneEventListeners() {
+      this.dropzoneNode.removeEventListener('dragover', this.handleDragOver);
+      this.dropzoneNode.removeEventListener('dragleave', this.handleDragLeave);
+      this.dropzoneNode.removeEventListener('drop', this.handleDrop);
+    }
+    addResizeEventListener() {
+      window.addEventListener('resize', this.fitHeaderColumns);
+    }
+
+    removeResizeEventListener() {
+      window.removeEventListener('resize', this.fitHeaderColumns);
+    }
+
+    addClickEventListener() {
+      this.modalNode = this.dropzoneNode.closest('.modal');
+      if (this.modalNode) {
+        this.modalNode.addEventListener('click', this.handleClickDropzone);
+      }
+    }
+
+    removeClickEventListener() {
+      if (this.modalNode) {
+        this.modalNode.removeEventListener('click', this.handleClickDropzone);
+        this.modalNode = null;
+      }
+    }
+
+    loadFiles() {
+      this.setState({ refreshing: true });
 
       api.watch.getFiles({ path: '' })
         .then((res) => {
@@ -41,25 +103,124 @@ class WatchDirectory extends PureComponent {
 
           const tree = this.treeNode.tree;
           tree.loadData(data);
-
+          this.props.actions.updateModalParams({ selectedNode: null });
           this.fitHeaderColumns();
         })
         .catch((res) => {
           // Ignore error
+        })
+        .then(() => {
+          this.setState({ refreshing: false });
         });
     }
 
-    componentWillUnmount() {
-      this.removeResizeEventListener();
-    }
+    handleClickUpload = () => {
+      this.uploadInputEl.value = null;
+      this.uploadInputEl.click();
+    };
 
-    addResizeEventListener() {
-      window.addEventListener('resize', this.fitHeaderColumns);
-    }
+    handleChangeUploadFiles = (event) => {
+      const files = Array.from(event.target.files || []);
+      this.uploadFiles(files);
+    };
 
-    removeResizeEventListener() {
-      window.removeEventListener('resize', this.fitHeaderColumns);
-    }
+    handleDragOver = (event) => {
+      event.preventDefault();
+      event.dataTransfer.dropEffect = 'copy';
+      if (!this.state.dragging) {
+        this.setState({ dragging: true });
+      }
+    };
+
+    handleDragLeave = (event) => {
+      event.preventDefault();
+      if (!this.dropzoneNode || !this.dropzoneNode.contains(event.relatedTarget)) {
+        this.setState({ dragging: false });
+      }
+    };
+
+    handleDrop = (event) => {
+      event.preventDefault();
+      this.setState({ dragging: false });
+      const files = Array.from(event.dataTransfer.files || []);
+      this.uploadFiles(files);
+    };
+
+    handleClickDropzone = (event) => {
+      const tree = this.treeNode && this.treeNode.tree;
+      if (!tree) {
+        return;
+      }
+      const row = event.target.closest('[data-id]');
+      if (!row) {
+        // Clicked outside the table: deselect the current file
+        tree.selectNode(null);
+        return;
+      }
+      const node = tree.getNodeById(row.getAttribute('data-id'));
+      if (node && node.props.type === 'd' && event.detail <= 1 && !event.target.closest('[class*="toggler"]')) {
+        // Single click on a folder toggles expansion (the chevron is handled by the tree)
+        if (node.state.open) {
+          tree.closeNode(node);
+        } else {
+          tree.openNode(node);
+        }
+      }
+    };
+
+    handleWatchDirChange = () => {
+      // Coalesce bursts of file system events before refreshing
+      clearTimeout(this.watchDirChangeTimer);
+      this.watchDirChangeTimer = setTimeout(() => {
+        this.loadFiles();
+      }, 200);
+    };
+
+    uploadFiles = (files) => {
+      if (files.length === 0 || this.state.uploading) {
+        return;
+      }
+      this.setState({ uploading: true, uploadProgress: 0 });
+
+      const readers = files.map((file) => new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onloadend = () => {
+          resolve({ file, data: reader.result });
+        };
+        reader.onerror = reject;
+        reader.readAsText(file);
+      }));
+
+      Promise.all(readers)
+        .then((results) => {
+          // Aggregate upload progress across files, weighted by file size
+          const progressOf = new Map(results.map(({ file }) => [file, 0]));
+          const totalBytes = results.reduce((sum, { file }) => sum + file.size, 0);
+          const updateProgress = () => {
+            const uploaded = [...progressOf.values()].reduce((sum, value) => sum + value, 0);
+            const percent = totalBytes > 0 ? (uploaded / totalBytes) * 100 : 100;
+            this.setState({ uploadProgress: Math.min(100, Math.round(percent)) });
+          };
+          const onProgress = (file) => (event) => {
+            const { direction, loaded = 0 } = { ...event };
+            if (direction !== 'upload') {
+              return;
+            }
+            progressOf.set(file, Math.min(loaded, file.size));
+            updateProgress();
+          };
+
+          return Promise.all(results.map(({ file, data }) => {
+            return api.watch.uploadFile({ file: file.name, data: data, onProgress: onProgress(file) });
+          }));
+        })
+        .catch((err) => {
+          log.error('Failed to upload files to the watch directory:', err);
+        })
+        .then(() => {
+          this.setState({ uploading: false, uploadProgress: 0 });
+        });
+    };
 
     addColumnGroup() {
       if (!this.treeNode) {
@@ -67,6 +228,9 @@ class WatchDirectory extends PureComponent {
       }
 
       this.treeNode.tree.scrollElement.style.height = '240px';
+      // Keep a constant vertical scrollbar gutter so it never covers the table
+      this.treeNode.tree.scrollElement.style.overflowY = 'scroll';
+      this.treeNode.tree.scrollElement.style.overflowX = 'hidden';
       const table = this.treeNode.tree.contentElement.parentNode;
       const colgroup = document.createElement('colgroup');
       table.appendChild(colgroup);
@@ -89,14 +253,41 @@ class WatchDirectory extends PureComponent {
       const colgroup = elTree.querySelector('colgroup');
       const row = elTree.querySelector('tbody > tr');
 
+      // Measure the natural width of each column
+      const widths = [];
       let i = 0;
       let child = row.firstChild;
       let col = colgroup.firstChild;
       while (child && col) {
-        const width = Math.max(child.clientWidth, tableHeaders[i].clientWidth);
-        col.style.minWidth = width + 'px';
-        col.style.width = width + 'px';
-        tableHeaders[i].style.width = width + 'px';
+        widths.push(Math.max(child.clientWidth, tableHeaders[i].clientWidth));
+        ++i;
+
+        child = child.nextSibling;
+        col = col.nextSibling;
+      }
+
+      // Reserve 8px on the right edge for the vertical scrollbar
+      const available = elTree.clientWidth - 8;
+
+      // Keep compact columns bounded so the name column gets the remaining space.
+      const maxColumnRatios = [0, 0.24, 0.14, 0.1];
+      for (let column = 1; column < widths.length; ++column) {
+        widths[column] = Math.min(
+          widths[column],
+          Math.round(available * maxColumnRatios[column])
+        );
+      }
+
+      const othersTotal = widths.slice(1).reduce((sum, width) => sum + width, 0);
+      widths[0] = Math.max(Math.round(available * 0.4), available - othersTotal);
+
+      i = 0;
+      child = row.firstChild;
+      col = colgroup.firstChild;
+      while (child && col) {
+        col.style.minWidth = widths[i] + 'px';
+        col.style.width = widths[i] + 'px';
+        tableHeaders[i].style.width = widths[i] + 'px';
         ++i;
 
         child = child.nextSibling;
@@ -107,124 +298,213 @@ class WatchDirectory extends PureComponent {
     render() {
       const { state, actions } = this.props;
       const { selectedNode = null } = state.modal.params;
+      const { dragging, uploading, uploadProgress, refreshing } = this.state;
       const canUpload = selectedNode && selectedNode.props.type === 'f';
 
       return (
-        <Modal disableOverlay size="md" onClose={actions.closeModal}>
+        <Modal disableOverlay size="md" style={{ width: '80vw' }} onClose={actions.closeModal}>
           <Modal.Header>
             <Modal.Title>{i18n._('Watch Directory')}</Modal.Title>
           </Modal.Header>
           <Modal.Body>
-            <table
-              ref={node => {
-                this.tableNode = node;
+            <div className={watchDirectoryStyles.toolbar}>
+              <input
+                ref={(node) => {
+                  this.uploadInputEl = node;
+                }}
+                type="file"
+                multiple={true}
+                style={{ display: 'none' }}
+                onChange={this.handleChangeUploadFiles}
+              />
+              <button
+                type="button"
+                className="btn btn-default"
+                onClick={this.handleClickUpload}
+                disabled={uploading}
+              >
+                <i aria-hidden="true" className="fa fa-plus" />
+                <Space width="4" />
+                {i18n._('Add')}
+              </button>
+              {uploading && (
+                <i aria-hidden="true" className="fa fa-circle-o-notch fa-spin" style={{ marginLeft: 8 }} />
+              )}
+              <button
+                type="button"
+                className="btn btn-default"
+                style={{ marginLeft: 'auto' }}
+                title={i18n._('Refresh')}
+                aria-label={i18n._('Refresh')}
+                onClick={() => this.loadFiles()}
+              >
+                <i aria-hidden="true" className={classNames('fa fa-refresh', { 'fa-spin': refreshing })} />
+              </button>
+            </div>
+            <div
+              ref={(node) => {
+                this.dropzoneNode = node;
               }}
-              style={{
-                width: '100%'
-              }}
+              className={classNames(watchDirectoryStyles.dropzone, {
+                [watchDirectoryStyles.dropzoneOver]: dragging
+              })}
             >
-              <thead>
-                <tr>
-                  <th>{i18n._('Name')}</th>
-                  <th>{i18n._('Date modified')}</th>
-                  <th>{i18n._('Type')}</th>
-                  <th>{i18n._('Size')}</th>
-                </tr>
-              </thead>
-            </table>
-            <InfiniteTree
-              style={{ height: 240 }}
-              ref={node => {
-                if (!this.treeNode) {
-                  this.treeNode = node;
-                  this.addColumnGroup();
-                }
-              }}
-              noDataClass={styles.noData}
-              togglerClass={styles.treeToggler}
-              autoOpen={true}
-              layout="table"
-              loadNodes={(parentNode, done) => {
-                api.watch.getFiles({ path: path.join(parentNode.props.path, parentNode.name) })
-                  .then((res) => {
-                    const body = res.body;
-                    const nodes = body.files.map((file) => {
-                      const { name, ...props } = file;
-
-                      return {
-                        id: path.join(body.path, name),
-                        name: name,
-                        props: {
-                          ...props,
-                          path: body.path || ''
-                        },
-                        loadOnDemand: (props.type === 'd')
-                      };
-                    });
-
-                    done(null, nodes);
-                  })
-                  .catch((res) => {
-                    // Ignore error
-                  });
-              }}
-              rowRenderer={renderer}
-              shouldSelectNode={(node) => {
-                const tree = this.treeNode.tree;
-                if (!node || (node === tree.getSelectedNode())) {
-                  return false; // Prevent from desdelecting the current node
-                }
-                return true;
-              }}
-              onContentDidUpdate={() => {
-                this.fitHeaderColumns();
-              }}
-              onKeyDown={(event) => {
-                // Prevent the default scroll
-                event.preventDefault();
-
-                const tree = this.treeNode.tree;
-                const node = tree.getSelectedNode();
-                const nodeIndex = tree.getSelectedIndex();
-
-                if (event.keyCode === 13) { // Enter
-                  if (!node) {
-                    return;
+              <table
+                ref={node => {
+                  this.tableNode = node;
+                }}
+                style={{
+                  width: '100%'
+                }}
+              >
+                <thead>
+                  <tr>
+                    <th style={{ paddingLeft: 20 }}>{i18n._('Name')}</th>
+                    <th>{i18n._('Date modified')}</th>
+                    <th>{i18n._('Type')}</th>
+                    <th>{i18n._('Size')}</th>
+                  </tr>
+                </thead>
+              </table>
+              <InfiniteTree
+                style={{ height: 240 }}
+                ref={node => {
+                  if (!this.treeNode) {
+                    this.treeNode = node;
+                    this.addColumnGroup();
                   }
-                  const file = path.join(node.props.path, node.name);
-                  actions.loadFile(file);
-                  actions.closeModal();
-                } else if (event.keyCode === 37) { // Left
-                  tree.closeNode(node);
-                } else if (event.keyCode === 38) { // Up
-                  const prevNode = tree.nodes[nodeIndex - 1] || node;
-                  tree.selectNode(prevNode);
-                } else if (event.keyCode === 39) { // Right
-                  tree.openNode(node);
-                } else if (event.keyCode === 40) { // Down
-                  const nextNode = tree.nodes[nodeIndex + 1] || node;
-                  tree.selectNode(nextNode);
-                }
-              }}
-              onSelectNode={(node) => {
-                actions.updateModalParams({ selectedNode: node });
-              }}
-              onDoubleClick={(event) => {
-                event.stopPropagation();
+                }}
+                noDataClass={styles.noData}
+                togglerClass={styles.treeToggler}
+                autoOpen={true}
+                layout="table"
+                loadNodes={(parentNode, done) => {
+                  api.watch.getFiles({ path: path.join(parentNode.props.path, parentNode.name) })
+                    .then((res) => {
+                      const body = res.body;
+                      const nodes = body.files.map((file) => {
+                        const { name, ...props } = file;
 
-                // Call setTimeout(fn, 0) to make sure it returns the last selected node
-                setTimeout(() => {
+                        return {
+                          id: path.join(body.path, name),
+                          name: name,
+                          props: {
+                            ...props,
+                            path: body.path || ''
+                          },
+                          loadOnDemand: (props.type === 'd')
+                        };
+                      });
+
+                      done(null, nodes);
+                    })
+                    .catch((res) => {
+                      // Ignore error
+                    });
+                }}
+                rowRenderer={renderer}
+                shouldSelectNode={(node) => {
+                  const tree = this.treeNode.tree;
+                  if (node && (node === tree.getSelectedNode())) {
+                    return false; // Prevent from deselecting the current node
+                  }
+                  return true;
+                }}
+                onContentDidUpdate={() => {
+                  this.fitHeaderColumns();
+                }}
+                onKeyDown={(event) => {
+                  // Prevent the default scroll
+                  event.preventDefault();
+
                   const tree = this.treeNode.tree;
                   const node = tree.getSelectedNode();
+                  const nodeIndex = tree.getSelectedIndex();
 
-                  if (node) {
+                  if (event.keyCode === 13) { // Enter
+                    if (!node) {
+                      return;
+                    }
+                    if (node.props.type === 'd') {
+                      // Toggle expansion for directories
+                      if (node.state.open) {
+                        tree.closeNode(node);
+                      } else {
+                        tree.openNode(node);
+                      }
+                      return;
+                    }
                     const file = path.join(node.props.path, node.name);
                     actions.loadFile(file);
                     actions.closeModal();
+                  } else if (event.keyCode === 37) { // Left
+                    tree.closeNode(node);
+                  } else if (event.keyCode === 38) { // Up
+                    const prevNode = tree.nodes[nodeIndex - 1] || node;
+                    tree.selectNode(prevNode);
+                  } else if (event.keyCode === 39) { // Right
+                    tree.openNode(node);
+                  } else if (event.keyCode === 40) { // Down
+                    const nextNode = tree.nodes[nodeIndex + 1] || node;
+                    tree.selectNode(nextNode);
                   }
-                }, 0);
-              }}
-            />
+                }}
+                onSelectNode={(node) => {
+                  actions.updateModalParams({ selectedNode: node });
+                }}
+                onDoubleClick={(event) => {
+                  event.stopPropagation();
+
+                  // Call setTimeout(fn, 0) to make sure it returns the last selected node
+                  setTimeout(() => {
+                    const tree = this.treeNode.tree;
+                    const node = tree.getSelectedNode();
+
+                    if (node) {
+                      if (node.props.type === 'd') {
+                        // Toggle expansion for directories
+                        if (node.state.open) {
+                          tree.closeNode(node);
+                        } else {
+                          tree.openNode(node);
+                        }
+                        return;
+                      }
+                      const file = path.join(node.props.path, node.name);
+                      actions.loadFile(file);
+                      actions.closeModal();
+                    }
+                  }, 0);
+                }}
+              />
+              {dragging && (
+                <div className={watchDirectoryStyles.dropzoneHint}>
+                  <i aria-hidden="true" className="fa fa-upload" />
+                  <Space width="8" />
+                  {i18n._('Drop files to upload')}
+                </div>
+              )}
+              {uploading && (
+                <div className={watchDirectoryStyles.dropzoneHint}>
+                  <div className={watchDirectoryStyles.progressLabel}>
+                    <i aria-hidden="true" className="fa fa-circle-o-notch fa-spin" />
+                    <Space width="8" />
+                    {i18n._('Uploading...')} {uploadProgress}%
+                  </div>
+                  <div className="progress" style={{ marginBottom: 0 }}>
+                    <div
+                      className="progress-bar"
+                      role="progressbar"
+                      aria-label={i18n._('Uploading...')}
+                      aria-valuenow={uploadProgress}
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                      style={{ width: uploadProgress + '%' }}
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
           </Modal.Body>
           <Modal.Footer>
             <button

--- a/src/app/widgets/Visualizer/WorkflowControl.jsx
+++ b/src/app/widgets/Visualizer/WorkflowControl.jsx
@@ -1,8 +1,10 @@
 import get from 'lodash/get';
 import includes from 'lodash/includes';
 import pick from 'lodash/pick';
+import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
+import api from 'app/api';
 import { Button, ButtonGroup, ButtonToolbar } from 'app/components/Buttons';
 import Dropdown, { MenuItem } from 'app/components/Dropdown';
 import Space from 'app/components/Space';
@@ -36,11 +38,31 @@ class WorkflowControl extends PureComponent {
       actions: PropTypes.object
     };
 
+    state = {
+      savePermanently: false,
+      watchDirectoryConfigured: false
+    };
+
     fileInputEl = null;
+
+    componentDidMount() {
+      api.watch.getStatus()
+        .then((res) => {
+          const { configured = false } = { ...res.body };
+          this.setState({ watchDirectoryConfigured: configured });
+        })
+        .catch((res) => {
+          // Ignore error
+        });
+    }
 
     handleClickUpload = (event) => {
       this.fileInputEl.value = null;
       this.fileInputEl.click();
+    };
+
+    handleChangeSavePermanently = (event) => {
+      this.setState({ savePermanently: event.target.checked });
     };
 
     handleChangeFile = (event) => {
@@ -68,7 +90,8 @@ class WorkflowControl extends PureComponent {
 
         const meta = {
           name: file.name,
-          size: file.size
+          size: file.size,
+          savePermanently: this.state.savePermanently && this.state.watchDirectoryConfigured
         };
         actions.uploadFile(result, meta);
       };
@@ -242,6 +265,22 @@ class WorkflowControl extends PureComponent {
               </Button>
             </ButtonGroup>
           </ButtonToolbar>
+          <div
+            className={cx('checkbox', {
+              'disabled': !this.state.watchDirectoryConfigured
+            })}
+            style={{ marginTop: 5, marginBottom: 0 }}
+          >
+            <label title={this.state.watchDirectoryConfigured ? undefined : i18n._('No watch directory is configured on the server')}>
+              <input
+                type="checkbox"
+                checked={this.state.savePermanently}
+                onChange={this.handleChangeSavePermanently}
+                disabled={!this.state.watchDirectoryConfigured}
+              />
+              {i18n._('Save to Watch Directory')}
+            </label>
+          </div>
         </div>
       );
     }

--- a/src/app/widgets/Visualizer/WorkflowControl.jsx
+++ b/src/app/widgets/Visualizer/WorkflowControl.jsx
@@ -3,7 +3,6 @@ import includes from 'lodash/includes';
 import pick from 'lodash/pick';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import api from 'app/api';
 import { Button, ButtonGroup, ButtonToolbar } from 'app/components/Buttons';
 import Dropdown, { MenuItem } from 'app/components/Dropdown';
 import Space from 'app/components/Space';
@@ -37,31 +36,11 @@ class WorkflowControl extends PureComponent {
       actions: PropTypes.object
     };
 
-    state = {
-      savePermanently: false,
-      watchDirectoryConfigured: false
-    };
-
     fileInputEl = null;
-
-    componentDidMount() {
-      api.watch.getStatus()
-        .then((res) => {
-          const { configured = false } = { ...res.body };
-          this.setState({ watchDirectoryConfigured: configured });
-        })
-        .catch((res) => {
-          // Ignore error
-        });
-    }
 
     handleClickUpload = (event) => {
       this.fileInputEl.value = null;
       this.fileInputEl.click();
-    };
-
-    handleChangeSavePermanently = (event) => {
-      this.setState({ savePermanently: event.target.checked });
     };
 
     handleChangeFile = (event) => {
@@ -89,8 +68,7 @@ class WorkflowControl extends PureComponent {
 
         const meta = {
           name: file.name,
-          size: file.size,
-          savePermanently: this.state.savePermanently && this.state.watchDirectoryConfigured
+          size: file.size
         };
         actions.uploadFile(result, meta);
       };
@@ -264,18 +242,6 @@ class WorkflowControl extends PureComponent {
               </Button>
             </ButtonGroup>
           </ButtonToolbar>
-          {this.state.watchDirectoryConfigured && (
-            <div className="checkbox" style={{ marginTop: 5, marginBottom: 0 }}>
-              <label>
-                <input
-                  type="checkbox"
-                  checked={this.state.savePermanently}
-                  onChange={this.handleChangeSavePermanently}
-                />
-                {i18n._('Save to Watch Directory')}
-              </label>
-            </div>
-          )}
         </div>
       );
     }

--- a/src/app/widgets/Visualizer/WorkflowControl.jsx
+++ b/src/app/widgets/Visualizer/WorkflowControl.jsx
@@ -1,7 +1,6 @@
 import get from 'lodash/get';
 import includes from 'lodash/includes';
 import pick from 'lodash/pick';
-import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import api from 'app/api';
@@ -265,22 +264,18 @@ class WorkflowControl extends PureComponent {
               </Button>
             </ButtonGroup>
           </ButtonToolbar>
-          <div
-            className={cx('checkbox', {
-              'disabled': !this.state.watchDirectoryConfigured
-            })}
-            style={{ marginTop: 5, marginBottom: 0 }}
-          >
-            <label title={this.state.watchDirectoryConfigured ? undefined : i18n._('No watch directory is configured on the server')}>
-              <input
-                type="checkbox"
-                checked={this.state.savePermanently}
-                onChange={this.handleChangeSavePermanently}
-                disabled={!this.state.watchDirectoryConfigured}
-              />
-              {i18n._('Save to Watch Directory')}
-            </label>
-          </div>
+          {this.state.watchDirectoryConfigured && (
+            <div className="checkbox" style={{ marginTop: 5, marginBottom: 0 }}>
+              <label>
+                <input
+                  type="checkbox"
+                  checked={this.state.savePermanently}
+                  onChange={this.handleChangeSavePermanently}
+                />
+                {i18n._('Save to Watch Directory')}
+              </label>
+            </div>
+          )}
         </div>
       );
     }

--- a/src/app/widgets/Visualizer/index.jsx
+++ b/src/app/widgets/Visualizer/index.jsx
@@ -8,6 +8,7 @@ import pubsub from 'pubsub-js';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import Anchor from 'app/components/Anchor';
+import api from 'app/api';
 import { Button } from 'app/components/Buttons';
 import ModalTemplate from 'app/components/ModalTemplate';
 import Modal from 'app/components/Modal';
@@ -253,8 +254,15 @@ class VisualizerWidget extends PureComponent {
         });
       },
       uploadFile: (gcode, meta) => {
-        const { name } = { ...meta };
+        const { name, savePermanently } = { ...meta };
         const context = {};
+
+        if (savePermanently) {
+          api.watch.uploadFile({ file: name, data: gcode })
+            .catch((res) => {
+              log.error(`Failed to save "${name}" to the watch directory`);
+            });
+        }
 
         this.setState((state) => ({
           gcode: {

--- a/src/app/widgets/Visualizer/index.jsx
+++ b/src/app/widgets/Visualizer/index.jsx
@@ -8,7 +8,6 @@ import pubsub from 'pubsub-js';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import Anchor from 'app/components/Anchor';
-import api from 'app/api';
 import { Button } from 'app/components/Buttons';
 import ModalTemplate from 'app/components/ModalTemplate';
 import Modal from 'app/components/Modal';
@@ -254,15 +253,8 @@ class VisualizerWidget extends PureComponent {
         });
       },
       uploadFile: (gcode, meta) => {
-        const { name, savePermanently } = { ...meta };
+        const { name } = { ...meta };
         const context = {};
-
-        if (savePermanently) {
-          api.watch.uploadFile({ file: name, data: gcode })
-            .catch((res) => {
-              log.error(`Failed to save "${name}" to the watch directory`);
-            });
-        }
 
         this.setState((state) => ({
           gcode: {

--- a/src/app/widgets/Visualizer/renderer.jsx
+++ b/src/app/widgets/Visualizer/renderer.jsx
@@ -166,7 +166,7 @@ const renderer = (node, treeOptions) => {
       disabled={disabled}
     >
       <TreeNodeColumn>
-        <div style={{ paddingLeft: paddingLeft }}>
+        <div className={styles.treeNameCell} title={node.name} style={{ paddingLeft: paddingLeft }}>
           <TreeNodeToggler
             show={more || loadOnDemand}
             expanded={more && open}
@@ -190,7 +190,7 @@ const renderer = (node, treeOptions) => {
       <TreeNodeColumn className="text-nowrap">
         {type}
       </TreeNodeColumn>
-      <TreeNodeColumn className="text-nowrap text-right">
+      <TreeNodeColumn className="text-nowrap">
         {size}
       </TreeNodeColumn>
     </TreeNode>

--- a/src/app/widgets/Visualizer/renderer.styl
+++ b/src/app/widgets/Visualizer/renderer.styl
@@ -1,7 +1,7 @@
 @import "nib";
 
 .tree-node {
-    cursor: default;
+    cursor: pointer;
 
     .selected&,
     .selected&:hover {

--- a/src/app/widgets/Visualizer/watch-directory.styl
+++ b/src/app/widgets/Visualizer/watch-directory.styl
@@ -1,0 +1,50 @@
+@import "nib";
+
+.toolbar {
+    display: flex;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.dropzone {
+    position: relative;
+    overflow-x: hidden;
+
+    th:last-child,
+    td:last-child {
+        padding-right: 12px;
+    }
+}
+
+.tree-name-cell {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.dropzone-over {
+    outline: 2px dashed #337ab7;
+    outline-offset: -2px;
+}
+
+.dropzone-hint {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    min-width: 280px;
+    padding: 12px 24px;
+    border: 2px dashed #337ab7;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, .9);
+    color: #337ab7;
+    font-size: 14px;
+    pointer-events: none;
+    white-space: nowrap;
+}
+
+.progress-label {
+    display: flex;
+    align-items: center;
+    margin-bottom: 8px;
+}

--- a/src/server/api/api.watch.js
+++ b/src/server/api/api.watch.js
@@ -1,8 +1,13 @@
 import monitor from '../services/monitor';
 import {
+  ERR_BAD_REQUEST,
   ERR_NOT_FOUND,
   ERR_INTERNAL_SERVER_ERROR
 } from '../constants';
+
+export const getStatus = (req, res) => {
+  res.send({ configured: monitor.isConfigured() });
+};
 
 export const getFiles = (req, res) => {
   const path = req.body.path || req.query.path || '';
@@ -29,5 +34,28 @@ export const readFile = (req, res) => {
     }
 
     res.send({ file: file, data: data });
+  });
+};
+
+export const writeFile = (req, res) => {
+  const file = req.body.file || '';
+  const data = req.body.data || '';
+
+  if (!file) {
+    res.status(ERR_BAD_REQUEST).send({
+      msg: 'No file specified'
+    });
+    return;
+  }
+
+  monitor.writeFile(file, data, (err) => {
+    if (err) {
+      res.status(err.message === 'Watch directory is not configured' ? ERR_BAD_REQUEST : ERR_INTERNAL_SERVER_ERROR).send({
+        msg: err.message || 'Failed writing file'
+      });
+      return;
+    }
+
+    res.send({ file: file });
   });
 };

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -318,10 +318,12 @@ const appMain = () => {
     app.delete(urljoin(settings.route, 'api/users/:id'), api.users.__delete);
 
     // Watch
+    app.get(urljoin(settings.route, 'api/watch/status'), api.watch.getStatus);
     app.get(urljoin(settings.route, 'api/watch/files'), api.watch.getFiles);
     app.post(urljoin(settings.route, 'api/watch/files'), api.watch.getFiles);
     app.get(urljoin(settings.route, 'api/watch/file'), api.watch.readFile);
     app.post(urljoin(settings.route, 'api/watch/file'), api.watch.readFile);
+    app.put(urljoin(settings.route, 'api/watch/file'), api.watch.writeFile);
   }
 
   // page

--- a/src/server/services/cncengine/CNCEngine.js
+++ b/src/server/services/cncengine/CNCEngine.js
@@ -9,6 +9,7 @@ import settings from '../../config/settings';
 import store from '../../store';
 import config from '../configstore';
 import taskRunner from '../taskrunner';
+import monitor from '../monitor';
 import {
   GrblController,
   MarlinController,
@@ -72,6 +73,11 @@ class CNCEngine {
         if (this.io) {
           this.io.emit('config:change', ...args);
         }
+      },
+      watchDirectoryChange: (...args) => {
+        if (this.io) {
+          this.io.emit('watchdir:change', ...args);
+        }
       }
     };
 
@@ -127,6 +133,7 @@ class CNCEngine {
       taskRunner.on('finish', this.listener.taskFinish);
       taskRunner.on('error', this.listener.taskError);
       config.on('change', this.listener.configChange);
+      monitor.on('change', this.listener.watchDirectoryChange);
 
       // System Trigger: Startup
       this.event.trigger('startup');
@@ -370,6 +377,7 @@ class CNCEngine {
       taskRunner.removeListener('finish', this.listener.taskFinish);
       taskRunner.removeListener('error', this.listener.taskError);
       config.removeListener('change', this.listener.configChange);
+      monitor.removeListener('change', this.listener.watchDirectoryChange);
     }
 }
 

--- a/src/server/services/monitor/FSMonitor.js
+++ b/src/server/services/monitor/FSMonitor.js
@@ -1,6 +1,7 @@
+import { EventEmitter } from 'events';
 import watch from 'watch';
 
-class FSMonitor {
+class FSMonitor extends EventEmitter {
     root = '';
 
     monitor = null;
@@ -16,12 +17,15 @@ class FSMonitor {
 
         monitor.on('created', (f, stat) => {
           this.files[f] = stat;
+          this.emit('created', f);
         });
         monitor.on('changed', (f, curr, prev) => {
           this.files[f] = curr;
+          this.emit('changed', f);
         });
         monitor.on('removed', (f, stat) => {
           delete this.files[f];
+          this.emit('removed', f);
         });
       });
     }

--- a/src/server/services/monitor/index.js
+++ b/src/server/services/monitor/index.js
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'events';
 import fs from 'fs';
 import path from 'path';
 import minimatch from 'minimatch';
@@ -5,8 +6,20 @@ import FSMonitor from './FSMonitor';
 
 const monitor = new FSMonitor();
 
+const emitter = new EventEmitter();
+
 const start = ({ watchDirectory }) => {
   monitor.watch(watchDirectory);
+
+  monitor.on('created', (file) => {
+    emitter.emit('change', { file });
+  });
+  monitor.on('changed', (file) => {
+    emitter.emit('change', { file });
+  });
+  monitor.on('removed', (file) => {
+    emitter.emit('change', { file });
+  });
 };
 
 const stop = () => {
@@ -85,11 +98,21 @@ const writeFile = (file, data, callback) => {
   fs.writeFile(target, data, 'utf8', callback);
 };
 
+const on = (...args) => {
+  emitter.on(...args);
+};
+
+const removeListener = (...args) => {
+  emitter.removeListener(...args);
+};
+
 export default {
   start,
   stop,
   isConfigured,
   getFiles,
   readFile,
-  writeFile
+  writeFile,
+  on,
+  removeListener
 };

--- a/src/server/services/monitor/index.js
+++ b/src/server/services/monitor/index.js
@@ -13,6 +13,8 @@ const stop = () => {
   monitor.unwatch();
 };
 
+const isConfigured = () => Boolean(monitor.root);
+
 const getFiles = (searchPath) => {
   const root = path.normalize(monitor.root);
   const files = Object.keys(monitor.files);
@@ -68,9 +70,26 @@ const readFile = (file, callback) => {
   fs.readFile(file, 'utf8', callback);
 };
 
+const writeFile = (file, data, callback) => {
+  const root = monitor.root;
+
+  if (!root) {
+    callback(new Error('Watch directory is not configured'));
+    return;
+  }
+
+  // Strip any directory components to prevent writing outside of the watched directory
+  const filename = path.basename(file);
+  const target = path.join(root, filename);
+
+  fs.writeFile(target, data, 'utf8', callback);
+};
+
 export default {
   start,
   stop,
+  isConfigured,
   getFiles,
-  readFile
+  readFile,
+  writeFile
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2859,7 +2859,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.14.5, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.28.6":
+"@babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.28.6":
   version: 7.28.6
   resolution: "@babel/runtime@npm:7.28.6"
   checksum: 42d8a868c2fc2e9a77927945a6daa7ec03c7ea49e611e0d15442933cdabb12f20e3a6849c729259076c10a4247adec229331d1f94c2d0073ea0979d7853e29fd
@@ -8727,7 +8727,7 @@ __metadata:
     react-final-form: ~3.7.0
     react-foreach: ~0.1.1
     react-ga4: ^2.1.0
-    react-i18next: ~11.18.6
+    react-i18next: ^8.0.0
     react-icon-base: ~2.1.2
     react-infinite-tree: ~0.7.1
     react-redux: ~5.0.7
@@ -9478,6 +9478,19 @@ __metadata:
     loose-envify: ^1.3.1
     object-assign: ^4.1.1
   checksum: 0c5f43da705fa9f67ec289051dd5780792652d440dfa17cd2c7d8423c1f604609596f895dabf46fda1960ddd93ee96fe1b61ef4d55a94fc4271b07d515486714
+  languageName: node
+  linkType: hard
+
+"create-react-context@npm:0.2.3":
+  version: 0.2.3
+  resolution: "create-react-context@npm:0.2.3"
+  dependencies:
+    fbjs: ^0.8.0
+    gud: ^1.0.0
+  peerDependencies:
+    prop-types: ^15.0.0
+    react: ^0.14.0 || ^15.0.0 || ^16.0.0
+  checksum: c48829815c90dc8fcd80a1542c70920fe9a1ba18c5f226de42f2494a82701fc5ca5197a64a412dcf1bf6e54b9ea603a8d14ad38df7870ed798490a505b38ac89
   languageName: node
   linkType: hard
 
@@ -11942,7 +11955,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fbjs@npm:^0.8.1, fbjs@npm:^0.8.16, fbjs@npm:^0.8.9":
+"fbjs@npm:^0.8.0, fbjs@npm:^0.8.1, fbjs@npm:^0.8.16, fbjs@npm:^0.8.9":
   version: 0.8.18
   resolution: "fbjs@npm:0.8.18"
   dependencies:
@@ -13036,6 +13049,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gud@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "gud@npm:1.0.0"
+  checksum: 3e2eb37cf794364077c18f036d6aa259c821c7fd188f2b7935cb00d589d82a41e0ebb1be809e1a93679417f62f1ad0513e745c3cf5329596e489aef8c5e5feae
+  languageName: node
+  linkType: hard
+
 "gulp-sort@npm:^2.0.0":
   version: 2.0.0
   resolution: "gulp-sort@npm:2.0.0"
@@ -13345,6 +13365,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hoist-non-react-statics@npm:3.0.1":
+  version: 3.0.1
+  resolution: "hoist-non-react-statics@npm:3.0.1"
+  dependencies:
+    react-is: ^16.3.2
+  peerDependencies:
+    react: ">=14.x"
+  checksum: 22f67780d3597c075582fc0b1c8e9072d0dc8785a9ee7be8412c2943a246021fbad15e1267a9001db1671b03d78357eb850a6ee4c984fd507452571ce02fa246
+  languageName: node
+  linkType: hard
+
 "hoist-non-react-statics@npm:^2.3.1, hoist-non-react-statics@npm:^2.5.0":
   version: 2.5.5
   resolution: "hoist-non-react-statics@npm:2.5.5"
@@ -13420,12 +13451,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-parse-stringify@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "html-parse-stringify@npm:3.0.1"
+"html-parse-stringify2@npm:2.0.1":
+  version: 2.0.1
+  resolution: "html-parse-stringify2@npm:2.0.1"
   dependencies:
-    void-elements: 3.1.0
-  checksum: 334fdebd4b5c355dba8e95284cead6f62bf865a2359da2759b039db58c805646350016d2017875718bc3c4b9bf81a0d11be5ee0cf4774a3a5a7b97cde21cfd67
+    void-elements: ^2.0.1
+  checksum: 165ba4048798511d58ab70a9a76c08cafdbf6ee7356ce4d504eba8fd70d7443dc254f7f52fdc63212a41d7a2934382eba30673372be1bf18710a63cdec4617f2
   languageName: node
   linkType: hard
 
@@ -19371,21 +19402,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-i18next@npm:~11.18.6":
-  version: 11.18.6
-  resolution: "react-i18next@npm:11.18.6"
+"react-i18next@npm:^8.0.0":
+  version: 8.4.0
+  resolution: "react-i18next@npm:8.4.0"
   dependencies:
-    "@babel/runtime": ^7.14.5
-    html-parse-stringify: ^3.0.1
+    "@babel/runtime": ^7.1.2
+    create-react-context: 0.2.3
+    hoist-non-react-statics: 3.0.1
+    html-parse-stringify2: 2.0.1
   peerDependencies:
-    i18next: ">= 19.0.0"
-    react: ">= 16.8.0"
-  peerDependenciesMeta:
-    react-dom:
-      optional: true
-    react-native:
-      optional: true
-  checksum: 624c0a0313fac4e0d18560b83c99a8bd0a83abc02e5db8d01984e0643ac409d178668aa3a4720d01f7a0d9520d38598dcbff801d6f69a970bae67461de6cd852
+    i18next: ">= 6.0.1"
+    prop-types: 15.6.2
+    react: ^0.14.0 ||^15.0.0 || ^16.0.0
+  checksum: 12ce069f8b9c3144cb44763da8f39e89ac6ca32bc5f480b88c730a4c8d7eba0ba029baf3a30fe6f2025eb0572076ff2906dd1fb5649f19d1bd25029f1aadd27f
   languageName: node
   linkType: hard
 
@@ -23380,10 +23409,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"void-elements@npm:3.1.0":
-  version: 3.1.0
-  resolution: "void-elements@npm:3.1.0"
-  checksum: 0390f818107fa8fce55bb0a5c3f661056001c1d5a2a48c28d582d4d847347c2ab5b7f8272314cac58acf62345126b6b09bea623a185935f6b1c3bbce0dfd7f7f
+"void-elements@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "void-elements@npm:2.0.1"
+  checksum: 700c07ba9cfa2dff88bb23974b3173118f9ad8107143db9e5d753552be15cf93380954d4e7f7d7bc80e7306c35c3a7fb83ab0ce4d4dcc18abf90ca8b31452126
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary
Adds an option to permanently save uploaded G-code files to the configured watch directory, instead of them only being held in memory for the current session.

### Problem
Uploading a G-code file only loaded it into the controller's in-memory sender — nothing was written to disk. A browser refresh or server restart meant re-uploading from scratch every time.

### Solution
Added a "Save to Watch Directory" checkbox next to the upload button. When checked, the uploaded file is also written to the server's watch directory (existing in-memory load behavior is unchanged).
The checkbox only appears if the server has a watchDirectory configured.
Re-uploading a same-named file overwrites it.
Unchecked uploads behave exactly as before (temporary, in-memory only).

### Changes

**Backend**
`monitor/index.js`: added writeFile() (path-traversal-safe via path.basename) and isConfigured().
`api.watch.js`: added writeFile and getStatus handlers.
`app.js`: registered GET /api/watch/status and PUT /api/watch/file.

**Frontend**
`api/index.js`: added watch.getStatus() and watch.uploadFile().
`WorkflowControl.jsx`: fetches watch-directory status on mount, conditionally renders the checkbox, passes savePermanently to the upload action.
`Visualizer/index.jsx`: uploadFile also calls api.watch.uploadFile when savePermanently is set (save failures are logged, don't block the normal load).

**Misc**
Fixed eslint-debug npm script to use cross-env for cross-platform compatibility (unrelated pre-existing bug, caught by the pre-push hook).