### PR TITLE
fix: upgrade i18next-fs-backend to 2.6.6 (CVE-2026-48713)

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "i18next": "~25.8.17",
     "i18next-browser-languagedetector": "~8.2.1",
     "i18next-express-middleware": "~1.8.0",
-    "i18next-fs-backend": "~2.6.1",
+    "i18next-fs-backend": "2.6.6",
     "i18next-http-backend": "~3.0.2",
     "i18next-http-middleware": "~3.9.2",
     "i18next-node-fs-backend": "~2.1.3",

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "i18next": "~25.8.17",
     "i18next-browser-languagedetector": "~8.2.1",
     "i18next-express-middleware": "~1.8.0",
-    "i18next-fs-backend": "2.6.6",
+    "i18next-fs-backend": "~2.6.6",
     "i18next-http-backend": "~3.0.2",
     "i18next-http-middleware": "~3.9.2",
     "i18next-node-fs-backend": "~2.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8680,7 +8680,7 @@ __metadata:
     i18next: ~25.8.17
     i18next-browser-languagedetector: ~8.2.1
     i18next-express-middleware: ~1.8.0
-    i18next-fs-backend: ~2.6.1
+    i18next-fs-backend: 2.6.6
     i18next-http-backend: ~3.0.2
     i18next-http-middleware: ~3.9.2
     i18next-node-fs-backend: ~2.1.3
@@ -13680,10 +13680,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"i18next-fs-backend@npm:~2.6.1":
-  version: 2.6.1
-  resolution: "i18next-fs-backend@npm:2.6.1"
-  checksum: 78a85714f92a029bb16818cfd45bd91322cd3b64e3c02b47d8b4c7ca82f00be762eda3b3ed032c17ef7b6482df91e78e27725f1bb2aa121101654abca91fcbe8
+"i18next-fs-backend@npm:2.6.6":
+  version: 2.6.6
+  resolution: "i18next-fs-backend@npm:2.6.6"
+  checksum: 0055e737379d29bac8230b057325e5d2e9311dd12cfd65ad1053fd78bade0d020d1a16b549de311b20c41106c50013019a22fe70d6e0585e07196f6a11c958ab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Upgrade i18next-fs-backend from 2.6.1 to 2.6.6 to fix CVE-2026-48713.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-48713 |
| **Severity** | CRITICAL |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-48713` |
| **File** | `yarn.lock` (dependency: `i18next-fs-backend`) |
| **Assessment** | Likely exploitable |

**Description**: i18next-fs-backend vulnerable to prototype pollution via crafted missing-key string

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-48713` flagged this pattern.

## Changes
- `package.json`
- `yarn.lock`

## Behavior Preservation
This change touches only dependency manifests (`package.json`, `yarn.lock`); no source file in the repository is modified.

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=CVE-2026-48713 scanner=trivy vuln=CVE-2026-48713 -->
